### PR TITLE
feature/68 글 상세화면에 글이 작성된 시간을 "1분 전"과 같은 형태로 표시한다. 

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7113,6 +7113,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10714,6 +10719,14 @@
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
+      }
+    },
+    "vue-moment": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
+      "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
+      "requires": {
+        "moment": "^2.19.2"
       }
     },
     "vue-router": {

--- a/front/package.json
+++ b/front/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "moment": "^2.27.0",
     "vue": "^2.6.11",
+    "vue-moment": "^4.1.0",
     "vue-router": "^3.2.0",
     "vuetify": "^2.2.11",
     "vuex": "^3.4.0"

--- a/front/package.json
+++ b/front/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "moment": "^2.27.0",
     "vue": "^2.6.11",
     "vue-moment": "^4.1.0",
     "vue-router": "^3.2.0",

--- a/front/src/components/post/CommentItem.vue
+++ b/front/src/components/post/CommentItem.vue
@@ -22,8 +22,6 @@
 </template>
 
 <script>
-import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
-
 export default {
   name: "CommentItem",
   data() {
@@ -38,8 +36,7 @@ export default {
     },
   },
   async mounted() {
-    console.log(this.comment);
-    this.commentDate = CHANGE_DATE_FROM_NOW(this.comment.createdAt);
+    this.commentDate = this.$moment(this.comment.createdAt).fromNow();
   },
 };
 </script>

--- a/front/src/components/post/CommentItem.vue
+++ b/front/src/components/post/CommentItem.vue
@@ -11,7 +11,7 @@
       </div>
       <div>{{ comment.content }}</div>
       <div>
-        <span class="text--disabled comment-created">1분 전</span>
+        <span class="text--disabled comment-created">{{ commentDate }}</span>
         <span class="float-right">
           <v-icon small>mdi-heart-outline</v-icon>
           <span class="mx-1">0</span>
@@ -22,13 +22,24 @@
 </template>
 
 <script>
+import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
+
 export default {
   name: "CommentItem",
+  data() {
+    return {
+      commentDate: "",
+    };
+  },
   props: {
     comment: {
       type: Object,
       required: true,
     },
+  },
+  async mounted() {
+    console.log(this.comment);
+    this.commentDate = CHANGE_DATE_FROM_NOW(this.comment.createdAt);
   },
 };
 </script>

--- a/front/src/components/post/CommentItem.vue
+++ b/front/src/components/post/CommentItem.vue
@@ -24,19 +24,16 @@
 <script>
 export default {
   name: "CommentItem",
-  data() {
-    return {
-      commentDate: "",
-    };
-  },
   props: {
     comment: {
       type: Object,
       required: true,
     },
   },
-  async mounted() {
-    this.commentDate = this.$moment(this.comment.createdAt).fromNow();
+  computed: {
+    commentDate() {
+      return this.$moment(this.comment.createdAt).fromNow();
+    },
   },
 };
 </script>

--- a/front/src/components/post/PostDetailPage.vue
+++ b/front/src/components/post/PostDetailPage.vue
@@ -72,7 +72,7 @@ export default {
   },
   watch: {
     post() {
-      this.postDate = this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
+      this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
     },
   },
 };

--- a/front/src/components/post/PostDetailPage.vue
+++ b/front/src/components/post/PostDetailPage.vue
@@ -3,7 +3,7 @@
     <div class="mb-3">
       <v-icon x-large class="mr-3">mdi-account-circle</v-icon>
       <span class="font-weight-bold">{{ post.memberResponse.nickname }}</span>
-      <div class="float-right mt-2">1분 전</div>
+      <div class="float-right mt-2">{{ postDate }}</div>
     </div>
     <div class="text--disabled post-address">
       {{ post.authorAddress.depth1 }}
@@ -22,60 +22,70 @@
         {{ post.address.depth3 }}에서
       </div>
     </div>
-    <CommentList :comments="post.comments" />
-    <div class="bottom-spacer" />
-    <CommentInput :post-id="post.id" />
+    <CommentList :comments="post.comments"/>
+    <div class="bottom-spacer"/>
+    <CommentInput :post-id="post.id"/>
   </div>
 </template>
 
 <script>
-import CommentInput from "@/components/post/CommentInput";
-import CommentList from "@/components/post/CommentList";
+  import CommentInput from "@/components/post/CommentInput";
+  import CommentList from "@/components/post/CommentList";
+  import moment from "moment";
 
-export default {
-  name: "PostDetailPage",
-  components: {
-    CommentList,
-    CommentInput,
-  },
-  data() {
-    return {
-      post: {
-        id: 0,
-        memberResponse: {
+  export default {
+    name: "PostDetailPage",
+    components: {
+      CommentList,
+      CommentInput,
+    },
+    data() {
+      return {
+        post: {
           id: 0,
-          nickname: "",
+          memberResponse: {
+            id: 0,
+            nickname: "",
+          },
+          content: "",
+          address: {
+            depth1: "",
+            depth2: "",
+            depth3: "",
+          },
+          authorAddress: {
+            depth1: "",
+            depth2: "",
+            depth3: "",
+          },
+          createdAt: "",
+          comments: [],
         },
-        content: "",
-        address: {
-          depth1: "",
-          depth2: "",
-          depth3: "",
-        },
-        authorAddress: {
-          depth1: "",
-          depth2: "",
-          depth3: "",
-        },
-        createdAt: "",
-        comments: [],
-      },
-    };
-  },
-  async created() {
-    this.post = await this.$store.dispatch(
-      "post/loadPost",
-      this.$route.params.id,
-    );
-  },
-};
+        postDate: "",
+      };
+    },
+    async created() {
+      this.post = await this.$store.dispatch(
+          "post/loadPost",
+          this.$route.params.id,
+      );
+    },
+    watch: {
+      post() {
+        console.log(this.post.createdAt);
+        const date = new Date(moment(this.post.createdAt).format('YYYY-MM-DD HH:mm:ss'));
+        this.postDate = moment(date).fromNow();
+      }
+    }
+  };
 </script>
 
 <style scoped>
-.post-address {
-  font-size: 0.9rem;
-}
-.bottom-spacer {
-  height: 60px;
-}
+  .post-address {
+    font-size: 0.9rem;
+  }
+
+  .bottom-spacer {
+    height: 60px;
+  }
 </style>

--- a/front/src/components/post/PostDetailPage.vue
+++ b/front/src/components/post/PostDetailPage.vue
@@ -60,7 +60,6 @@ export default {
         createdAt: "",
         comments: [],
       },
-      postDate: "",
     };
   },
   async created() {
@@ -68,8 +67,13 @@ export default {
       "post/loadPost",
       this.$route.params.id,
     );
-    this.postDate = await this.$moment(this.post.createdAt).fromNow();
   },
+  computed: {
+    postDate() {
+      return this.$moment(this.post.createdAt).fromNow();
+    }
+  }
+
 };
 </script>
 

--- a/front/src/components/post/PostDetailPage.vue
+++ b/front/src/components/post/PostDetailPage.vue
@@ -31,7 +31,6 @@
 <script>
 import CommentInput from "@/components/post/CommentInput";
 import CommentList from "@/components/post/CommentList";
-import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
 
 export default {
   name: "PostDetailPage",
@@ -69,11 +68,7 @@ export default {
       "post/loadPost",
       this.$route.params.id,
     );
-  },
-  watch: {
-    post() {
-      this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
-    },
+    this.postDate = await this.$moment(this.post.createdAt).fromNow();
   },
 };
 </script>

--- a/front/src/components/post/PostDetailPage.vue
+++ b/front/src/components/post/PostDetailPage.vue
@@ -22,70 +22,68 @@
         {{ post.address.depth3 }}에서
       </div>
     </div>
-    <CommentList :comments="post.comments"/>
-    <div class="bottom-spacer"/>
-    <CommentInput :post-id="post.id"/>
+    <CommentList :comments="post.comments" />
+    <div class="bottom-spacer" />
+    <CommentInput :post-id="post.id" />
   </div>
 </template>
 
 <script>
-  import CommentInput from "@/components/post/CommentInput";
-  import CommentList from "@/components/post/CommentList";
-  import moment from "moment";
+import CommentInput from "@/components/post/CommentInput";
+import CommentList from "@/components/post/CommentList";
+import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
 
-  export default {
-    name: "PostDetailPage",
-    components: {
-      CommentList,
-      CommentInput,
-    },
-    data() {
-      return {
-        post: {
+export default {
+  name: "PostDetailPage",
+  components: {
+    CommentList,
+    CommentInput,
+  },
+  data() {
+    return {
+      post: {
+        id: 0,
+        memberResponse: {
           id: 0,
-          memberResponse: {
-            id: 0,
-            nickname: "",
-          },
-          content: "",
-          address: {
-            depth1: "",
-            depth2: "",
-            depth3: "",
-          },
-          authorAddress: {
-            depth1: "",
-            depth2: "",
-            depth3: "",
-          },
-          createdAt: "",
-          comments: [],
+          nickname: "",
         },
-        postDate: "",
-      };
+        content: "",
+        address: {
+          depth1: "",
+          depth2: "",
+          depth3: "",
+        },
+        authorAddress: {
+          depth1: "",
+          depth2: "",
+          depth3: "",
+        },
+        createdAt: "",
+        comments: [],
+      },
+      postDate: "",
+    };
+  },
+  async created() {
+    this.post = await this.$store.dispatch(
+      "post/loadPost",
+      this.$route.params.id,
+    );
+  },
+  watch: {
+    post() {
+      this.postDate = this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
     },
-    async created() {
-      this.post = await this.$store.dispatch(
-          "post/loadPost",
-          this.$route.params.id,
-      );
-    },
-    watch: {
-      post() {
-        console.log(this.post.createdAt);
-        const date = new Date(moment(this.post.createdAt).format('YYYY-MM-DD HH:mm:ss'));
-        this.postDate = moment(date).fromNow();
-      }
-    }
-  };
+  },
+};
 </script>
 
 <style scoped>
-  .post-address {
-    font-size: 0.9rem;
-  }
+.post-address {
+  font-size: 0.9rem;
+}
 
-  .bottom-spacer {
-    height: 60px;
-  }
+.bottom-spacer {
+  height: 60px;
+}
 </style>

--- a/front/src/components/timeline/PostItem.vue
+++ b/front/src/components/timeline/PostItem.vue
@@ -18,7 +18,6 @@
 
 <script>
 import router from "@/router";
-import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
 
 export default {
   name: "PostItem",
@@ -34,7 +33,7 @@ export default {
     },
   },
   async mounted() {
-    this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
+    this.postDate = this.$moment(this.post.createdAt).fromNow();
   },
   methods: {
     routePage() {

--- a/front/src/components/timeline/PostItem.vue
+++ b/front/src/components/timeline/PostItem.vue
@@ -21,19 +21,16 @@ import router from "@/router";
 
 export default {
   name: "PostItem",
-  data() {
-    return {
-      postDate: "",
-    };
-  },
   props: {
     post: {
       type: Object,
       required: true,
     },
   },
-  async mounted() {
-    this.postDate = this.$moment(this.post.createdAt).fromNow();
+  computed: {
+    postDate() {
+      return this.$moment(this.post.createdAt).fromNow();
+    },
   },
   methods: {
     routePage() {

--- a/front/src/components/timeline/PostItem.vue
+++ b/front/src/components/timeline/PostItem.vue
@@ -3,7 +3,7 @@
     <div class="my-2">
       <v-icon large class="mr-3">mdi-account-circle</v-icon>
       <span class="font-weight-bold">{{ post.memberResponse.nickname }}</span>
-      <div class="float-right mt-1">1분 전</div>
+      <div class="float-right mt-1">{{ postDate }}</div>
     </div>
     <div class="text-break">{{ post.content }}</div>
     <div class="text-right">
@@ -18,14 +18,23 @@
 
 <script>
 import router from "@/router";
+import { CHANGE_DATE_FROM_NOW } from "@/utils/moment";
 
 export default {
   name: "PostItem",
+  data() {
+    return {
+      postDate: "",
+    };
+  },
   props: {
     post: {
       type: Object,
       required: true,
     },
+  },
+  async mounted() {
+    this.postDate = CHANGE_DATE_FROM_NOW(this.post.createdAt);
   },
   methods: {
     routePage() {

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -3,6 +3,7 @@ import App from "@/App.vue";
 import router from "@/router";
 import store from "@/store";
 import vuetify from "@/plugins/vuetify";
+import momentLocale from "moment/locale/ko";
 import KakaoMap from "@/plugins/kakao-map";
 
 Vue.config.productionTip = false;
@@ -13,5 +14,6 @@ new Vue({
   router,
   store,
   vuetify,
+  momentLocale,
   render: (h) => h(App),
 }).$mount("#app");

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -7,6 +7,7 @@ import KakaoMap from "@/plugins/kakao-map";
 
 Vue.config.productionTip = false;
 Vue.use(KakaoMap);
+Vue.use(require("vue-moment"));
 
 new Vue({
   router,

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -3,17 +3,21 @@ import App from "@/App.vue";
 import router from "@/router";
 import store from "@/store";
 import vuetify from "@/plugins/vuetify";
-import momentLocale from "moment/locale/ko";
 import KakaoMap from "@/plugins/kakao-map";
 
 Vue.config.productionTip = false;
 Vue.use(KakaoMap);
-Vue.use(require("vue-moment"));
+
+const moment = require("moment");
+require("moment/locale/ko");
+
+Vue.use(require("vue-moment"), {
+  moment,
+});
 
 new Vue({
   router,
   store,
   vuetify,
-  momentLocale,
   render: (h) => h(App),
 }).$mount("#app");

--- a/front/src/utils/moment.js
+++ b/front/src/utils/moment.js
@@ -1,5 +1,0 @@
-import moment from "moment";
-
-export const CHANGE_DATE_FROM_NOW = (date) => {
-  return moment(date).fromNow();
-};

--- a/front/src/utils/moment.js
+++ b/front/src/utils/moment.js
@@ -1,0 +1,5 @@
+import moment from "moment";
+
+export const CHANGE_DATE_FROM_NOW = (date) => {
+  return moment(date).fromNow();
+};

--- a/src/main/java/com/grasshouse/dorandoran/comment/service/dto/CommentResponse.java
+++ b/src/main/java/com/grasshouse/dorandoran/comment/service/dto/CommentResponse.java
@@ -2,6 +2,7 @@ package com.grasshouse.dorandoran.comment.service.dto;
 
 import com.grasshouse.dorandoran.comment.domain.Comment;
 import com.grasshouse.dorandoran.member.service.dto.MemberResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotBlank;
@@ -31,6 +32,10 @@ public class CommentResponse {
 
     @NotNull
     private Double distance;
+
+    @NotNull
+    private LocalDateTime createdAt;
+
     //TODO : comment_like 정보 추후에 추가하기
 
     public static CommentResponse from(Comment comment) {
@@ -40,6 +45,7 @@ public class CommentResponse {
             .postId(comment.getPost().getId())
             .content(comment.getContent())
             .distance(comment.getDistance())
+            .createdAt(comment.getCreatedAt())
             .build();
     }
 

--- a/src/main/java/com/grasshouse/dorandoran/post/service/dto/PostResponse.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/service/dto/PostResponse.java
@@ -5,6 +5,7 @@ import com.grasshouse.dorandoran.member.service.dto.MemberResponse;
 import com.grasshouse.dorandoran.post.domain.Address;
 import com.grasshouse.dorandoran.post.domain.Location;
 import com.grasshouse.dorandoran.post.domain.Post;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +40,9 @@ public class PostResponse {
     @NotNull
     private Address address;
 
+    @NotNull
+    private LocalDateTime createdAt;
+
     @Builder.Default
     private final List<CommentResponse> comments = new ArrayList<>();
     //TODO : post_like 정보 추후에 추가하기
@@ -51,6 +55,7 @@ public class PostResponse {
             .content(post.getContent())
             .location(post.getLocation())
             .address(post.getAddress())
+            .createdAt(post.getCreatedAt())
             .comments(CommentResponse.listFrom(post.getComments()))
             .build();
     }


### PR DESCRIPTION
Resolves #68

글이 등록한 시간이 현재 시간으로부터 얼마나 떨어져있는지 표시하도록 합니다.
moment.js를 사용했습니다.

![image](https://user-images.githubusercontent.com/19922698/89711896-24a98f00-d9c8-11ea-93e4-c873555d4dd2.png)


월요일까지 리뷰 부탁드려요 🙂 