### PR TITLE
feature/174 상세화면 지도 위치 모달창 표시 이후 생기는 문제 해결

### DIFF
--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -80,7 +80,7 @@ export default {
       this.$router.go(-1);
     },
     setMapDefault() {
-      this.$store.commit("map/CHANGE_STATE", MAP_MODE.DEFAULT);
+      this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
     toggleSearchInput() {

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -80,7 +80,7 @@ export default {
       this.$router.go(-1);
     },
     setMapDefault() {
-      this.$store.commit("mapMode/CHANGE_STATE", MAP_MODE.DEFAULT);
+      this.$store.commit("map/CHANGE_STATE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
     toggleSearchInput() {

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -35,7 +35,8 @@ export default {
     },
   },
   async mounted() {
-    await this.$kakaoMap.drawMap(this.$refs.map);
+    const map = await this.$kakaoMap.drawMap(this.$refs.map);
+    this.$store.commit("mapMode/SET_MAP", map);
     await this.$kakaoMap
       .setCenterByCurrentLocation()
       .catch(() =>

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -25,10 +25,10 @@ export default {
   },
   computed: {
     isDefaultMode() {
-      return this.$store.getters["mapMode/isDefault"];
+      return this.$store.getters["map/isDefault"];
     },
     isMarkerMode() {
-      return this.$store.getters["mapMode/isMarker"];
+      return this.$store.getters["map/isMarker"];
     },
     posts() {
       return this.$store.getters["post/posts"];
@@ -36,7 +36,7 @@ export default {
   },
   async mounted() {
     const map = await this.$kakaoMap.drawMap(this.$refs.map);
-    this.$store.commit("mapMode/SET_MAP", map);
+    this.$store.commit("map/SET_MAP", map);
     await this.$kakaoMap
       .setCenterByCurrentLocation()
       .catch(() =>

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -53,13 +53,13 @@ export default {
   },
   computed: {
     isDefaultMode() {
-      return this.$store.getters["mapMode/isDefault"];
+      return this.$store.getters["map/isDefault"];
     },
     isMarkerMode() {
-      return this.$store.getters["mapMode/isMarker"];
+      return this.$store.getters["map/isMarker"];
     },
     isPostMode() {
-      return this.$store.getters["mapMode/isPost"];
+      return this.$store.getters["map/isPost"];
     },
   },
   created() {

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -48,11 +48,11 @@ export default {
   methods: {
     changeMode() {
       if (this.isDefaultMode) {
-        this.$store.commit("map/CHANGE_STATE", MAP_MODE.MARKER);
+        this.$store.commit("map/CHANGE_MODE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
       } else if (this.isMarkerMode) {
-        this.$store.commit("map/CHANGE_STATE", MAP_MODE.POST);
+        this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }
     },
   },

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -33,13 +33,13 @@ export default {
   name: "PostCreateButton",
   computed: {
     isDefaultMode() {
-      return this.$store.getters["mapMode/isDefault"];
+      return this.$store.getters["map/isDefault"];
     },
     isMarkerMode() {
-      return this.$store.getters["mapMode/isMarker"];
+      return this.$store.getters["map/isMarker"];
     },
     isPostMode() {
-      return this.$store.getters["mapMode/isPost"];
+      return this.$store.getters["map/isPost"];
     },
     buttonType() {
       return this.isMarkerMode ? BUTTON_TYPE.MARKER : BUTTON_TYPE.DEFAULT;
@@ -48,11 +48,11 @@ export default {
   methods: {
     changeMode() {
       if (this.isDefaultMode) {
-        this.$store.commit("mapMode/CHANGE_STATE", MAP_MODE.MARKER);
+        this.$store.commit("map/CHANGE_STATE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
       } else if (this.isMarkerMode) {
-        this.$store.commit("mapMode/CHANGE_STATE", MAP_MODE.POST);
+        this.$store.commit("map/CHANGE_STATE", MAP_MODE.POST);
       }
     },
   },

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -97,7 +97,7 @@ export default {
       this.rendered = false;
     },
     closeModal() {
-      this.$store.commit("map/CHANGE_STATE", MAP_MODE.DEFAULT);
+      this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
   },

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -97,7 +97,7 @@ export default {
       this.rendered = false;
     },
     closeModal() {
-      this.$store.commit("mapMode/CHANGE_STATE", MAP_MODE.DEFAULT);
+      this.$store.commit("map/CHANGE_STATE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
   },

--- a/front/src/components/post/PostLocationModal.vue
+++ b/front/src/components/post/PostLocationModal.vue
@@ -29,7 +29,7 @@ export default {
     await this.$kakaoMap.drawMap(this.$refs.postMap);
     this.$kakaoMap.setCenterLocation(this.location);
     this.$kakaoMap.setMarker(this.location, MAP_MARKER_IMAGE);
-    const mainMap = this.$store.getters["mapMode/map"];
+    const mainMap = this.$store.getters["map/map"];
     this.$kakaoMap.setMap(mainMap);
   },
   methods: {

--- a/front/src/components/post/PostLocationModal.vue
+++ b/front/src/components/post/PostLocationModal.vue
@@ -29,6 +29,8 @@ export default {
     await this.$kakaoMap.drawMap(this.$refs.postMap);
     this.$kakaoMap.setCenterLocation(this.location);
     this.$kakaoMap.setMarker(this.location, MAP_MARKER_IMAGE);
+    const mainMap = this.$store.getters["mapMode/map"];
+    this.$kakaoMap.setMap(mainMap);
   },
   methods: {
     closeModal() {

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -252,7 +252,6 @@ export const KakaoMap = (() => {
     if (!map || !location) {
       return;
     }
-
     const address = await _getAdministrativeAddress(location);
     return {
       depth1: address[1].region_1depth_name,
@@ -265,7 +264,6 @@ export const KakaoMap = (() => {
     if (!map) {
       return;
     }
-
     map.addListener(eventType, func);
   };
 

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -105,6 +105,8 @@ export const KakaoMap = (() => {
     map = new kakao.maps.Map(mapContainer, options);
     postOverlays = [];
     clusterer = _createClusterer();
+
+    return map;
   };
 
   const _getGeolocation = () => {
@@ -267,6 +269,10 @@ export const KakaoMap = (() => {
     map.addListener(eventType, func);
   };
 
+  const setMap = (newMap) => {
+    map = newMap;
+  };
+
   return {
     drawMap,
     getCurrentLocation,
@@ -282,6 +288,7 @@ export const KakaoMap = (() => {
     clearPostOverlay,
     getAddress,
     addEventToMap,
+    setMap,
   };
 })();
 

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -7,7 +7,7 @@ import memberSidebar from "@/store/modules/memberSidebar";
 import appBar from "@/store/modules/appBar";
 import filter from "@/store/modules/filter";
 import snackbar from "@/store/modules/snackbar";
-import mapMode from "@/store/modules/mapMode";
+import map from "@/store/modules/map";
 
 Vue.use(Vuex);
 
@@ -20,6 +20,6 @@ export default new Vuex.Store({
     appBar,
     filter,
     snackbar,
-    mapMode,
+    map,
   },
 });

--- a/front/src/store/modules/map.js
+++ b/front/src/store/modules/map.js
@@ -10,7 +10,7 @@ export default {
     SET_MAP(state, map) {
       state.map = map;
     },
-    CHANGE_STATE(state, target) {
+    CHANGE_MODE(state, target) {
       state.mode = target;
     },
   },

--- a/front/src/store/modules/map.js
+++ b/front/src/store/modules/map.js
@@ -4,14 +4,14 @@ export default {
   namespaced: true,
   state: {
     map: null,
-    mapMode: MAP_MODE.DEFAULT,
+    mode: MAP_MODE.DEFAULT,
   },
   mutations: {
     SET_MAP(state, map) {
       state.map = map;
     },
     CHANGE_STATE(state, target) {
-      state.mapMode = target;
+      state.mode = target;
     },
   },
   getters: {
@@ -19,13 +19,13 @@ export default {
       return state.map;
     },
     isDefault(state) {
-      return state.mapMode === MAP_MODE.DEFAULT;
+      return state.mode === MAP_MODE.DEFAULT;
     },
     isMarker(state) {
-      return state.mapMode === MAP_MODE.MARKER;
+      return state.mode === MAP_MODE.MARKER;
     },
     isPost(state) {
-      return state.mapMode === MAP_MODE.POST;
+      return state.mode === MAP_MODE.POST;
     },
   },
 };

--- a/front/src/store/modules/mapMode.js
+++ b/front/src/store/modules/mapMode.js
@@ -3,14 +3,21 @@ import { MAP_MODE } from "@/utils/constants";
 export default {
   namespaced: true,
   state: {
+    map: null,
     mapMode: MAP_MODE.DEFAULT,
   },
   mutations: {
+    SET_MAP(state, map) {
+      state.map = map;
+    },
     CHANGE_STATE(state, target) {
       state.mapMode = target;
     },
   },
   getters: {
+    map(state) {
+      return state.map;
+    },
     isDefault(state) {
       return state.mapMode === MAP_MODE.DEFAULT;
     },


### PR DESCRIPTION
resolves #174 

kakao-map plugin에서 관리하는 기존의 map을 덮어씌워 생기는 문제였습니다.
`$kakaoMap.drawMap()`이 map을 반환, vuex에서도 관리할 수 있도록 했습니다.

메인 지도에 대한 사용은 그대로 하셔도 됩니다.
만일 추가적으로 지도를 띄울 일이 생기면, 해당 지도 사용 후 마지막에 `$kakaoMap.setMap(this.$store.getters["map/map"])`을 통해서 vuex에 저장된 메인 지도를 다시 주입해주시면 됩니다.

약간 고민인게
kakaoMap 플러그인 자체는 하나의 지도만 사용하는 걸 전제로 할지, (현상 유지)
아니면 여러 지도를 사용할 가능성을 열어두기 위해 모든 메소드에서 map을 추가 인자로 받게 하는게 맞는지 헷갈리네요.
아마 후자가 되면 대규모 리펙토링 작업이 필요할 것 같아요.

map 객체의 관리 책임을 어디서 가져야할까요?
kakaoMap 플러그인은 유틸성 클래스가 되어서 가지고 있는 내부 변수 없이 모두 인자로 받아서 해결해야 할까요?
아니면 지금처럼 하나의 맵만 관리하도록 해야할까요?
다른 분들의 생각은 어떤가요?

```javascript
  const setPostOverlay = (map, clusterer, template, location) => {
    if (!map) {
      return;
    }
    const kakaoLocation = _createKakaoLocation(location);
    const overlay = _createOverlay(template, kakaoLocation);

    overlay.setMap(map);
    clusterer.addMarker(overlay);

    return overlay;
  };
```
만약 후자라면 모든 메소드가 이런식으로 변경되겠죠?
clusterer나 postOverlays도 외부에서 관리해야할 거 같아요.

어떻게 보면 기존 kakao에서 제공하는 api자체가 이런 식이네요.
생성되는 객체의 관리 책임은 다 api 호출자에게 넘기는군요.