### PR TITLE
feature/185 지도 마커 모드, 글 작성 모드 뒤로가기 시 기본 모드로 전환한다.

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -16,7 +16,6 @@
 import DoranAppBar from "@/components/DoranAppBar";
 import MemberSidebar from "@/components/member/MemberSidebar";
 import MemberUpdateModal from "@/components/member/MemberUpdateModal";
-import { MAP_MODE } from "@/utils/constants";
 
 export default {
   name: "App",
@@ -52,7 +51,6 @@ export default {
   async created() {
     this.checkUrl();
     await this.checkToken();
-    this.preventRoute();
     this.isInitialMember = this.$store.getters["member/isInitialMember"];
   },
   methods: {
@@ -70,15 +68,6 @@ export default {
       } else if (!storageToken) {
         await this.$router.push("/login");
       }
-    },
-    preventRoute() {
-      this.$router.beforeEach((to, from, next) => {
-        if (to.path === "/" || to.path === "/timeline") {
-          this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
-          this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
-        }
-        next(true);
-      });
     },
     closeMemberUpdateModal() {
       this.isInitialMember = false;

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -16,6 +16,7 @@
 import DoranAppBar from "@/components/DoranAppBar";
 import MemberSidebar from "@/components/member/MemberSidebar";
 import MemberUpdateModal from "@/components/member/MemberUpdateModal";
+import { MAP_MODE } from "@/utils/constants";
 
 export default {
   name: "App",
@@ -74,6 +75,7 @@ export default {
       this.$router.beforeEach((to, from, next) => {
         if (to.path === "/" || to.path === "/timeline") {
           this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+          this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
         }
         next(true);
       });

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -11,9 +11,6 @@
       <v-icon v-show="backButton" @click="goToPrevious">
         mdi-chevron-left
       </v-icon>
-      <v-icon v-show="cancelButton" @click="setMapDefault">
-        mdi-chevron-left
-      </v-icon>
 
       <v-toolbar-title class="app-bar-title font-size-small">
         {{ appBarTitle }}
@@ -45,7 +42,7 @@
 </template>
 
 <script>
-import { ERROR_MESSAGE, MAP_MODE } from "@/utils/constants";
+import { ERROR_MESSAGE } from "@/utils/constants";
 
 export default {
   name: "DoranAppBar",
@@ -62,9 +59,6 @@ export default {
     backButton() {
       return this.$store.getters["appBar/backButton"];
     },
-    cancelButton() {
-      return this.$store.getters["appBar/cancelButton"];
-    },
     appBarTitle() {
       return this.$store.getters["appBar/title"];
     },
@@ -78,10 +72,6 @@ export default {
     },
     goToPrevious() {
       this.$router.go(-1);
-    },
-    setMapDefault() {
-      this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
-      this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
     toggleSearchInput() {
       this.isSearching = !this.isSearching;

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -31,7 +31,6 @@ import MapAssistantButtons from "@/components/map/MapAssistantButtons";
 import PeriodFilterButton from "@/components/map/filter/PeriodFilterButton";
 import TimelineModal from "@/components/timeline/TimelineModal";
 import PostModal from "@/components/post/PostModal";
-import { MAP_MODE } from "@/utils/constants";
 
 export default {
   name: "MapPage",
@@ -68,21 +67,11 @@ export default {
     if (currentPath === "/post-create") {
       this.$router.push("/");
     }
-    this.preventRoute();
     this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
   },
   methods: {
     renderMap() {
       this.isMapRendered = true;
-    },
-    preventRoute() {
-      this.$router.beforeEach((to, from, next) => {
-        if (to.path === "/" || to.path === "/timeline") {
-          this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
-          this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
-        }
-        next(true);
-      });
     },
   },
   watch: {

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -64,6 +64,10 @@ export default {
     },
   },
   created() {
+    const currentPath = this.$router.history.current.path;
+    if (currentPath === "/post-create") {
+      this.$router.push("/");
+    }
     this.preventRoute();
     this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
   },

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -31,6 +31,7 @@ import MapAssistantButtons from "@/components/map/MapAssistantButtons";
 import PeriodFilterButton from "@/components/map/filter/PeriodFilterButton";
 import TimelineModal from "@/components/timeline/TimelineModal";
 import PostModal from "@/components/post/PostModal";
+import { MAP_MODE } from "@/utils/constants";
 
 export default {
   name: "MapPage",
@@ -63,11 +64,21 @@ export default {
     },
   },
   created() {
+    this.preventRoute();
     this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
   },
   methods: {
     renderMap() {
       this.isMapRendered = true;
+    },
+    preventRoute() {
+      this.$router.beforeEach((to, from, next) => {
+        if (to.path === "/" || to.path === "/timeline") {
+          this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+          this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
+        }
+        next(true);
+      });
     },
   },
   watch: {

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -48,10 +48,10 @@ export default {
   methods: {
     changeMode() {
       if (this.isDefaultMode) {
+        this.$router.push("/post-create");
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
-        this.$router.push("/post-create");
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -51,6 +51,7 @@ export default {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
+        this.$router.push("/post-create");
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -98,6 +98,7 @@ export default {
     closeModal() {
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+      this.$router.push("/");
     },
   },
 };

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -46,16 +46,32 @@ export default {
   name: "PostCreateModal",
   data() {
     return {
+      flag: false,
       content: "",
       location: this.$kakaoMap.getCenterLocation(),
       buttonColor: DORAN_DORAN_COLORS.POINT_COLOR,
       rendered: false,
     };
   },
+  created() {
+    this.preventRoute();
+  },
   mounted() {
     this.rendered = true;
   },
   methods: {
+    preventRoute() {
+      const preventRoute = this.$router.beforeEach((to, from, next) => {
+        if (this.flag) {
+          this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+          this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
+          next(true);
+        }
+        this.rendered = false;
+        next(false);
+      });
+      this.$once("hook:destroyed", preventRoute);
+    },
     async createPost() {
       if (this.content.trim() === "") {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_CONTENT_MESSAGE);
@@ -96,6 +112,7 @@ export default {
       this.rendered = false;
     },
     closeModal() {
+      this.flag = true;
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
       this.$router.push("/");

--- a/front/src/components/post/PostModal.vue
+++ b/front/src/components/post/PostModal.vue
@@ -60,7 +60,7 @@ import CommentList from "@/components/post/CommentList";
 import PostLocationModal from "@/components/post/PostLocationModal";
 import OptionsModal from "@/components/post/OptionsModal";
 import DoranAppBar from "@/components/DoranAppBar";
-import { ERROR_MESSAGE, LIKE_BUTTON_TYPE } from "@/utils/constants";
+import { ERROR_MESSAGE, LIKE_BUTTON_TYPE, MAP_MODE } from "@/utils/constants";
 
 const DELETE_POST_SUCCESS_MESSAGE = "👻 글이 삭제되었습니다.";
 const DELETE_POST_FAIL_MESSAGE = "😭 글 삭제에 실패했습니다.";
@@ -85,10 +85,7 @@ export default {
       return localStorage.getItem("accessToken");
     },
     isMine() {
-      return (
-        this.post.author.id ===
-        this.$store.getters["member/getMember"].id
-      );
+      return this.post.author.id === this.$store.getters["member/getMember"].id;
     },
     post: {
       get() {
@@ -118,8 +115,18 @@ export default {
   async created() {
     await this.$store.dispatch("post/loadPost", this.$route.params.id);
     this.$store.commit("appBar/POST_DETAIL_PAGE");
+    this.preventRoute();
   },
   methods: {
+    preventRoute() {
+      const preventRoute = this.$router.beforeEach((to, from, next) => {
+        this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+        this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
+        next(true);
+      });
+      this.$once("hook:destroyed", preventRoute);
+    },
+
     async remove() {
       await this.$store.dispatch("post/deletePost", this.post.id).catch((e) => {
         this.$store.commit("snackbar/SHOW", DELETE_POST_FAIL_MESSAGE);

--- a/front/src/components/timeline/TimelineModal.vue
+++ b/front/src/components/timeline/TimelineModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="modal-mask" @click.self="slideDown">
-    <transition name="slide-up" @after-leave="close">
+    <transition name="slide-up" @after-leave="closeModal">
       <div v-if="rendered" class="pa-3 modal-container">
         <div class="text-center">
           <span class="ma-auto text-center">타임라인</span>
@@ -55,7 +55,7 @@ export default {
     slideDown() {
       this.rendered = false;
     },
-    close() {
+    closeModal() {
       this.flag = true;
       this.$router.go(-1);
     },

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -18,6 +18,10 @@ const routes = [
     },
     children: [
       {
+        path: "post-create",
+        name: "PostCreate",
+      },
+      {
         path: "timeline",
         name: "TimelineModal",
         components: {

--- a/front/src/store/modules/appBar.js
+++ b/front/src/store/modules/appBar.js
@@ -3,7 +3,6 @@ export default {
   state: {
     myPageButton: false,
     backButton: false,
-    cancelButton: false,
     title: "",
     address: "",
     searchButton: false,
@@ -16,20 +15,17 @@ export default {
     MAP_PAGE_DEFAULT_MODE(state) {
       state.myPageButton = true;
       state.backButton = false;
-      state.cancelButton = false;
       state.title = state.address;
       state.searchButton = true;
     },
     MAP_PAGE_MARKER_MODE(state) {
       state.myPageButton = false;
-      state.backButton = false;
-      state.cancelButton = true;
+      state.backButton = true;
       state.searchButton = false;
     },
     POST_DETAIL_PAGE(state) {
       state.myPageButton = false;
       state.backButton = true;
-      state.cancelButton = false;
       state.title = "게시글";
       state.searchButton = false;
     },
@@ -40,9 +36,6 @@ export default {
     },
     backButton: (state) => {
       return state.backButton;
-    },
-    cancelButton: (state) => {
-      return state.cancelButton;
     },
     searchButton: (state) => {
       return state.searchButton;


### PR DESCRIPTION
resolve #185 

여태 뒤로가기 버튼을 막고 다른 행동을 할 수 있던 이유는 그게 router를 통한 이동이었기 때문이었어요....
이전 경로가 라우터를 통한 이동이 아니었다면, 뒤로가기 버튼은 그냥 브라우저의 이동이라(?) 기존의 `preventRoute()` 메소드가 안먹히더라고요...😭

그래서 결국 `/post-create`을 추가했습니다.
그 밖의 큰 변경 사항은 없는 것 같아요.
appbar의 cancelButton이 사라지고 backButton으로 통합되었다는 것 정도?

다른 이슈에 영향을 갈만한 친구는 아니라 천천히 리뷰해주셔도 괜찮을 것 같아요~