### PR TITLE
feature/206 vuex에서 post, filter 모듈 관계를 재정비한다.

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -74,10 +74,7 @@ export default {
       this.$router.beforeEach(async (to, from, next) => {
         if (to.path === "/" || to.path === "/timeline") {
           this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
-
-          this.$store.commit("post/CLEAR_POSTS");
-          const posts = await this.$store.dispatch("filter/filterPosts");
-          this.$store.commit("post/SET_POSTS", posts);
+          await this.$store.dispatch("post/loadPosts");
         }
         next(true);
       });

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -92,10 +92,8 @@ export default {
         return;
       }
       this.$store.commit("post/filter/SET_KEYWORD", this.keyword);
-      this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
-      if (filteredPosts.length === 0) {
+      await this.$store.dispatch("post/loadPosts");
+      if (this.$store.getters["post/posts"].length === 0) {
         this.$store.commit(
           "snackbar/SHOW",
           ERROR_MESSAGE.NO_SEARCH_RESULT_MESSAGE,
@@ -106,8 +104,7 @@ export default {
       this.toggleSearchInput();
       this.keyword = "";
       this.$store.commit("post/filter/SET_KEYWORD", "");
-      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
+      await this.$store.dispatch("post/loadPosts");
     },
   },
 };

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -93,7 +93,7 @@ export default {
       }
       this.$store.commit("post/filter/SET_KEYWORD", this.keyword);
       await this.$store.dispatch("post/loadPosts");
-      if (this.$store.getters["post/posts"].length === 0) {
+      if (this.$store.getters["post/isEmpty"]) {
         this.$store.commit(
           "snackbar/SHOW",
           ERROR_MESSAGE.NO_SEARCH_RESULT_MESSAGE,

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -91,9 +91,9 @@ export default {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_KEYWORD_INPUT);
         return;
       }
-      this.$store.commit("filter/SET_KEYWORD", this.keyword);
+      this.$store.commit("post/filter/SET_KEYWORD", this.keyword);
       this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
       if (filteredPosts.length === 0) {
         this.$store.commit(
@@ -105,8 +105,8 @@ export default {
     async initializeMapPage() {
       this.toggleSearchInput();
       this.keyword = "";
-      this.$store.commit("filter/SET_KEYWORD", "");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      this.$store.commit("post/filter/SET_KEYWORD", "");
+      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
     },
   },

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -46,8 +46,7 @@ export default {
         ),
       );
     await this.changeAppBarByCenterAddress();
-    const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-    this.$store.commit("post/SET_POSTS", filteredPosts);
+    await this.$store.dispatch("post/loadPosts");
     this.$kakaoMap.addEventToMap(
       EVENT_TYPE.CENTER_CHANGE,
       this.changeAppBarByCenterAddress,

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -46,7 +46,7 @@ export default {
         ),
       );
     await this.changeAppBarByCenterAddress();
-    const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+    const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
     this.$store.commit("post/SET_POSTS", filteredPosts);
     this.$kakaoMap.addEventToMap(
       EVENT_TYPE.CENTER_CHANGE,

--- a/front/src/components/map/MapAssistantButtons.vue
+++ b/front/src/components/map/MapAssistantButtons.vue
@@ -27,7 +27,7 @@ export default {
     },
     async refreshPosts() {
       this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
     },
   },

--- a/front/src/components/map/MapAssistantButtons.vue
+++ b/front/src/components/map/MapAssistantButtons.vue
@@ -26,9 +26,7 @@ export default {
         );
     },
     async refreshPosts() {
-      this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
+      await this.$store.dispatch("post/loadPosts");
     },
   },
 };

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -86,9 +86,7 @@ export default {
       });
       this.$store.commit("snackbar/SHOW", CREATE_POST_SUCCESS_MESSAGE);
       this.$kakaoMap.clearPostOverlay();
-      this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
+      await this.$store.dispatch("post/loadPosts");
       this.bounceOut();
     },
     bounceOut() {

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -87,7 +87,7 @@ export default {
       this.$store.commit("snackbar/SHOW", CREATE_POST_SUCCESS_MESSAGE);
       this.$kakaoMap.clearPostOverlay();
       this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
       this.bounceOut();
     },

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -106,10 +106,8 @@ export default {
       this.filterPosts();
     },
     async filterPosts() {
-      this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
-      if (filteredPosts.length === 0) {
+      await this.$store.dispatch("post/loadPosts");
+      if (this.$store.getters["post/posts"].length === 0) {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_POST_MESSAGE);
         return;
       }

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -107,7 +107,7 @@ export default {
     },
     async filterPosts() {
       await this.$store.dispatch("post/loadPosts");
-      if (this.$store.getters["post/posts"].length === 0) {
+      if (this.$store.getters["post/isEmpty"]) {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_POST_MESSAGE);
         return;
       }

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -77,20 +77,20 @@ export default {
     },
     loadPosts() {
       const startDate = this.selected.startDate();
-      this.$store.commit("filter/SET_START_DATE", startDate);
-      this.$store.commit("filter/RESET_END_DATE");
+      this.$store.commit("post/filter/SET_START_DATE", startDate);
+      this.$store.commit("post/filter/RESET_END_DATE");
       this.filterPosts();
     },
     inputStartDate(date) {
       this.startDate = period.format(date + " 00:00:00");
-      this.$store.commit("filter/SET_START_DATE", this.startDate);
+      this.$store.commit("post/filter/SET_START_DATE", this.startDate);
       if (this.endDate) {
         this.handleUserInputFiltering();
       }
     },
     inputEndDate(date) {
       this.endDate = period.format(date + " 23:59:59");
-      this.$store.commit("filter/SET_END_DATE", this.endDate);
+      this.$store.commit("post/filter/SET_END_DATE", this.endDate);
       if (this.startDate) {
         this.handleUserInputFiltering();
       }
@@ -107,7 +107,7 @@ export default {
     },
     async filterPosts() {
       this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      const filteredPosts = await this.$store.dispatch("post/filter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
       if (filteredPosts.length === 0) {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_POST_MESSAGE);
@@ -119,8 +119,8 @@ export default {
   watch: {
     async selected(val) {
       if (val === this.periodOptions.CUSTOM) {
-        this.$store.commit("filter/SET_START_DATE", this.startDate);
-        this.$store.commit("filter/SET_END_DATE", this.endDate);
+        this.$store.commit("post/filter/SET_START_DATE", this.startDate);
+        this.$store.commit("post/filter/SET_END_DATE", this.endDate);
         await this.filterPosts();
         this.openCalendar();
         return;

--- a/front/src/components/post/PostModal.vue
+++ b/front/src/components/post/PostModal.vue
@@ -127,7 +127,7 @@ export default {
       });
       this.$store.commit("snackbar/SHOW", DELETE_POST_SUCCESS_MESSAGE);
       this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("filter/filterPosts");
+      const filteredPosts = await this.$store.dispatch("postfilter/filterPosts");
       this.$store.commit("post/SET_POSTS", filteredPosts);
       this.$router.go(-1);
     },

--- a/front/src/components/post/PostModal.vue
+++ b/front/src/components/post/PostModal.vue
@@ -126,9 +126,7 @@ export default {
         throw e;
       });
       this.$store.commit("snackbar/SHOW", DELETE_POST_SUCCESS_MESSAGE);
-      this.$store.commit("post/CLEAR_POSTS");
-      const filteredPosts = await this.$store.dispatch("postfilter/filterPosts");
-      this.$store.commit("post/SET_POSTS", filteredPosts);
+      await this.$store.dispatch("post/loadPosts");
       this.$router.go(-1);
     },
     hasLike(like) {

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -5,7 +5,6 @@ import member from "@/store/modules/member";
 import post from "@/store/modules/post";
 import memberSidebar from "@/store/modules/memberSidebar";
 import appBar from "@/store/modules/appBar";
-import filter from "@/store/modules/filter";
 import snackbar from "@/store/modules/snackbar";
 import map from "@/store/modules/map";
 
@@ -18,7 +17,6 @@ export default new Vuex.Store({
     member,
     memberSidebar,
     appBar,
-    filter,
     snackbar,
     map,
   },

--- a/front/src/store/modules/post.js
+++ b/front/src/store/modules/post.js
@@ -81,6 +81,9 @@ export default {
     posts: (state) => {
       return state.posts;
     },
+    isEmpty: (state) => {
+      return state.posts.length === 0;
+    },
     postsInBounds: (state) => (bounds) => {
       return state.posts.filter(
         ({ location }) =>

--- a/front/src/store/modules/post.js
+++ b/front/src/store/modules/post.js
@@ -58,6 +58,11 @@ export default {
       const data = await api.loadPost(postId);
       commit("SET_POST", data);
     },
+    async loadPosts({ commit, dispatch }) {
+      commit("CLEAR_POSTS");
+      const posts = await dispatch("filter/filterPosts");
+      commit("SET_POSTS", posts);
+    },
     async deletePost({ commit }, postId) {
       await api.deletePost(postId);
       commit("REMOVE_POST", postId);

--- a/front/src/store/modules/post.js
+++ b/front/src/store/modules/post.js
@@ -1,7 +1,11 @@
 import api from "@/api/posts";
+import filter from "@/store/modules/filter";
 
 export default {
   namespaced: true,
+  modules: {
+    filter,
+  },
   state: {
     post: {
       id: 0,

--- a/front/src/store/modules/post.js
+++ b/front/src/store/modules/post.js
@@ -45,9 +45,6 @@ export default {
     CLEAR_POSTS(state) {
       state.posts = null;
     },
-    SET_TIMELINE_POSTS(state, timelinePosts) {
-      state.timelinePosts = timelinePosts;
-    },
     REMOVE_POST(state, postId) {
       const deleteIndex = state.posts.findIndex((post) => post.id === postId);
       state.posts.splice(deleteIndex, 1);


### PR DESCRIPTION
resolves #206 

post/filter/~로 사용 가능하게 바꿨습니다.
기존에는 loadPosts를 사용하기 위해서는
```javascript
this.$store.commit("post/CLEAR_POST");
const filteredPosts = await this.$store.dispatch("filter/filterPosts");
this.$store.commit("post/SET_POSTS", filteredPosts);
```

이런 방식으로 매번 3개나 되는 함수를 호출해야했습니다.
이제는 `await this.$store.dispatch("post/loadPosts");`한방으로 해결 가능합니다! 🎉