### PR TITLE
feature/214 build.gradle jacoco 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '2.3.1.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+    id 'jacoco'
     id 'java'
 }
 
@@ -43,6 +44,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 def querydslSrcDir = 'src/main/generated'
@@ -67,4 +69,11 @@ compileQuerydsl{
 
 configurations {
     querydsl.extendsFrom compileClasspath
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
 }


### PR DESCRIPTION
Resolves #214 

빌드 후 coverage report file 위치
`build/reports/jacoco/test/html/index.html`

소나큐브 적용(#213 )후 jacoco 연동 (jenkins빌드exec)
sonar.jacoco.reportPaths=build/reports/jacoco/test/jacocoTestReport.xml