### PR TITLE
hotfix/217 좋아요가 여러 개인 경우 댓글이 중복으로 보이는 문제 해결

### DIFF
--- a/src/main/java/com/grasshouse/dorandoran/post/service/PostService.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/service/PostService.java
@@ -6,12 +6,10 @@ import com.grasshouse.dorandoran.common.exception.MemberMismatchException;
 import com.grasshouse.dorandoran.common.exception.PostNotFoundException;
 import com.grasshouse.dorandoran.member.domain.Member;
 import com.grasshouse.dorandoran.post.domain.Post;
-import com.grasshouse.dorandoran.post.dto.PostBoundsRequest;
 import com.grasshouse.dorandoran.post.dto.PostCreateRequest;
 import com.grasshouse.dorandoran.post.dto.PostCreateResponse;
 import com.grasshouse.dorandoran.post.dto.PostResponse;
 import com.grasshouse.dorandoran.post.repository.PostRepository;
-import com.grasshouse.dorandoran.post.repository.PostRepositorySupport;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final PostRepositorySupport postRepositorySupport;
 
     @Transactional
     public PostCreateResponse createPost(PostCreateRequest request, Member member) {
@@ -34,8 +31,10 @@ public class PostService {
 
     @Transactional
     public PostResponse showPost(Long id) {
-        Post post = postRepositorySupport.findPostById(id);
-        return PostResponse.from(post);
+        Post post = postRepository.findById(id)
+            .orElseThrow(PostNotFoundException::new);
+
+        return PostResponse.from(post.filterAliveComments());
     }
 
     @Transactional


### PR DESCRIPTION
Resolves #217 

QueryDSL 메소드가 문제였기 때문에 우선 postRepository.findById로 바꾸었습니다.
정확한 이유는 아직 잘 모르겠습니다 더 공부해볼게요.