### PR TITLE
hotfix/223 댓글이 좋아요에 영향 받는 문제를 해결한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.grasshouse'
-version = '1.0.1-SNAPSHOT'
+version = '1.0.2-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 configurations {

--- a/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
@@ -1,11 +1,8 @@
 package com.grasshouse.dorandoran.post.repository;
 
-import static com.grasshouse.dorandoran.comment.domain.QComment.comment;
 import static com.grasshouse.dorandoran.post.domain.QPost.post;
-import static com.grasshouse.dorandoran.post.domain.QPostLike.postLike;
 
 import com.grasshouse.dorandoran.common.baseentity.EntityStatus;
-import com.grasshouse.dorandoran.common.exception.PostNotFoundException;
 import com.grasshouse.dorandoran.post.domain.Post;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -27,26 +24,9 @@ public class PostRepositorySupport extends QuerydslRepositorySupport {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    public Post findPostById(Long postId) {
-        Post persistPost = jpaQueryFactory.selectFrom(post)
-            .distinct()
-            .leftJoin(post.comments, comment).fetchJoin()
-            .leftJoin(post.likes, postLike).fetchJoin()
-            .where(post.id.eq(postId))
-            .where(isPostAlive())
-            .fetchFirst();
-
-        if (persistPost == null) {
-            throw new PostNotFoundException();
-        }
-        return persistPost.filterAliveComments();
-    }
-
     public List<Post> findPostWithKeywordAndDate(String keyword, LocalDateTime startDate, LocalDateTime endDate) {
         List<Post> persistPosts = jpaQueryFactory.selectFrom(post)
             .distinct()
-            .leftJoin(post.comments, comment).fetchJoin()
-            .leftJoin(post.likes, postLike).fetchJoin()
             .where(isPostAlive())
             .where(containsKeyword(keyword), betweenDate(startDate, endDate))
             .fetch();

--- a/src/test/java/com/grasshouse/dorandoran/post/domain/PostTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/post/domain/PostTest.java
@@ -1,0 +1,46 @@
+package com.grasshouse.dorandoran.post.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.grasshouse.dorandoran.comment.domain.Comment;
+import com.grasshouse.dorandoran.fixture.AddressFixture;
+import com.grasshouse.dorandoran.fixture.LocationFixture;
+import com.grasshouse.dorandoran.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostTest {
+
+    @DisplayName("삭제된 댓글을 필터링한다.")
+    @Test
+    void filterAliveComments() {
+        Post post = Post.builder()
+            .author(MemberFixture.PERSIST_MEMBER)
+            .content("내용")
+            .location(LocationFixture.JAMSIL_STATION)
+            .authorAddress(AddressFixture.AUTHOR_ADDRESS)
+            .address(AddressFixture.ADDRESS)
+            .build();
+
+        Comment comment1 = Comment.builder()
+            .author(MemberFixture.PERSIST_MEMBER)
+            .post(post)
+            .content("댓글1")
+            .distance(0.0)
+            .build();
+
+        Comment comment2 = Comment.builder()
+            .author(MemberFixture.PERSIST_MEMBER)
+            .post(post)
+            .content("댓글2")
+            .distance(0.0)
+            .build();
+
+        post.addComment(comment1);
+        post.addComment(comment2);
+        post.removeComment(comment2);
+
+        assertThat(post.filterAliveComments().getComments()).hasSize(1);
+    }
+}

--- a/src/test/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupportTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupportTest.java
@@ -1,6 +1,7 @@
 package com.grasshouse.dorandoran.post.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.grasshouse.dorandoran.comment.domain.Comment;
 import com.grasshouse.dorandoran.comment.repository.CommentRepository;
@@ -53,8 +54,12 @@ class PostRepositorySupportTest {
         List<Post> persistPosts = postRepositorySupport.findPostWithKeywordAndDate("글", null, null);
 
         assertThat(persistPosts).hasSize(1);
-        assertThat(persistPosts.get(0).getComments()).hasSize(1);
-        assertThat(persistPosts.get(0).getLikes()).hasSize(2);
+        assertAll(
+            () -> {
+                assertThat(persistPosts.get(0).getComments()).hasSize(1);
+                assertThat(persistPosts.get(0).getLikes()).hasSize(2);
+            }
+        );
     }
 
     @AfterEach

--- a/src/test/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupportTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupportTest.java
@@ -9,11 +9,14 @@ import com.grasshouse.dorandoran.fixture.LocationFixture;
 import com.grasshouse.dorandoran.member.domain.Member;
 import com.grasshouse.dorandoran.member.repository.MemberRepository;
 import com.grasshouse.dorandoran.post.domain.Post;
+import com.grasshouse.dorandoran.post.domain.PostLike;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class PostRepositorySupportTest {
@@ -28,78 +31,54 @@ class PostRepositorySupportTest {
     private CommentRepository commentRepository;
 
     @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    @Autowired
     private PostRepositorySupport postRepositorySupport;
 
-    @DisplayName("댓글이 없는 글을 조회한다.")
+    @DisplayName("post.comments, post.likes를 잘 가져오는지 테스트")
     @Test
-    void findPostByIdWithoutComments() {
-        Member member = SAVE_MEMBER();
+    @Transactional
+    void findPostWithKeywordAndDate() {
+        Member member1 = SAVE_MEMBER("멤버1", "oAuthId1");
+        Member member2 = SAVE_MEMBER("멤버2", "oAuthId2");
 
-        Post post = SAVE_POST(member);
+        Post post = SAVE_POST(member1);
 
-        assertThat(post.getComments()).hasSize(0);
+        Comment comment1 = SAVE_COMMENT(member1, post, "댓글1");
 
-        Post persistPost = postRepository.findById(post.getId()).get();
+        PostLike postLike1 = SAVE_POST_LIKE(member1.getId(), post);
+        PostLike postLike2 = SAVE_POST_LIKE(member2.getId(), post);
 
-        Post postById = postRepositorySupport.findPostById(persistPost.getId());
-        assertThat(postById.getComments()).hasSize(0);
-    }
+        List<Post> persistPosts = postRepositorySupport.findPostWithKeywordAndDate("글", null, null);
 
-    @DisplayName("삭제된 댓글만 있는 글을 조회한다.")
-    @Test
-    void findPostByIdWithComments1() {
-        Member member = SAVE_MEMBER();
-
-        Post post = SAVE_POST(member);
-
-        Comment comment1 = SAVE_COMMENT(member, post, "댓글1");
-
-        assertThat(post.getComments()).hasSize(1);
-
-        post.removeComment(comment1);
-        postRepository.save(post);
-        commentRepository.save(comment1);
-
-        Post postById = postRepositorySupport.findPostById(post.getId());
-
-        assertThat(postById.getComments()).hasSize(0);
-    }
-
-    @DisplayName("삭제되지 않은 댓글과 함께 글을 조회한다.")
-    @Test
-    void findPostByIdWithComments2() {
-        Member member = SAVE_MEMBER();
-
-        Post post = SAVE_POST(member);
-
-        Comment comment1 = SAVE_COMMENT(member, post, "댓글1");
-        Comment comment2 = SAVE_COMMENT(member, post, "댓글2");
-
-        assertThat(post.getComments()).hasSize(2);
-
-        post.removeComment(comment1);
-        postRepository.save(post);
-        commentRepository.save(comment1);
-
-        Post postById = postRepositorySupport.findPostById(post.getId());
-
-        assertThat(postById.getComments()).hasSize(1);
+        assertThat(persistPosts).hasSize(1);
+        assertThat(persistPosts.get(0).getComments()).hasSize(1);
+        assertThat(persistPosts.get(0).getLikes()).hasSize(2);
     }
 
     @AfterEach
     void tearDown() {
+        postLikeRepository.deleteAll();
         commentRepository.deleteAll();
         postRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
-    private Member SAVE_MEMBER() {
-        Member member = Member.builder()
-            .oAuthId("OAUTH_ID")
-            .nickname("NICKNAME")
+    private PostLike SAVE_POST_LIKE(Long memberId, Post post) {
+        PostLike postLike = PostLike.builder()
+            .memberId(memberId)
+            .post(post)
             .build();
-        memberRepository.save(member);
-        return member;
+        return postLikeRepository.save(postLike);
+    }
+
+    private Member SAVE_MEMBER(String nickname, String oAuthId) {
+        Member member = Member.builder()
+            .nickname(nickname)
+            .oAuthId(oAuthId)
+            .build();
+        return memberRepository.save(member);
     }
 
     private Post SAVE_POST(Member member) {


### PR DESCRIPTION
Resolves #223 

기존에 `post.comments`, `post.likes` 에 대해 `fetchJoin`을 사용하고 있었는데, Hibernate에서는 2개 이상의 컬렉션에서 `fetchJoin`을 사용하지 못한다고 합니다.
보통 이럴 경우에 `MultipleBagFetchException`이 발생하는데 저는 왜 안 터졌는지 모르겠어요. (QueryDSL이라 그런가..?)

급한 불을 끄기 위해 fetchJoin은 제거했고, N+1 문제가 발생합니다.
N+1 문제를 해결하기 위해 fetchJoin 외의 다른 방법을 찾아보고 있는데 설정에 `default_batch_fetch_size`를 적용하면 되는 것 같더라고요! 하지만 아직 원리가 잘 이해가 안 가서 이 친구는 다음 PR에 적용하겠습니다.

혹시 관심 있는 사람들은 저랑 함께 알아보아요 😀

자꾸 문제 일으켜서 죄송해요 ㅠㅠ