### PR TITLE
feature/185 글쓰기 버튼 클릭 후 뒤로가기 버튼이 페이지를 벗어나지 않도록 한다.

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -49,16 +49,21 @@ export default {
     },
   },
   async created() {
-    if (this.$route.path !== "/") {
-      await this.$router.push("/");
-    }
     this.checkUrl();
+    this.checkUrlToken();
     await this.checkToken();
     this.preventRoute();
     this.isInitialMember = this.$store.getters["member/isInitialMember"];
   },
   methods: {
     checkUrl() {
+      const isNotMapPage = this.$route.name !== "MapPage";
+      const isNotPostModal = this.$route.name !== "PostModal";
+      if (isNotMapPage && isNotPostModal) {
+        this.$router.push("/");
+      }
+    },
+    checkUrlToken() {
       const urlToken = location.href.split("token=")[1];
       if (urlToken) {
         localStorage.setItem("accessToken", urlToken);

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -49,6 +49,9 @@ export default {
     },
   },
   async created() {
+    if (this.$route.path !== "/") {
+      await this.$router.push("/");
+    }
     this.checkUrl();
     await this.checkToken();
     this.preventRoute();

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -11,9 +11,6 @@
       <v-icon v-show="backButton" @click="goToPrevious">
         mdi-chevron-left
       </v-icon>
-      <v-icon v-show="cancelButton" @click="setMapDefault">
-        mdi-chevron-left
-      </v-icon>
 
       <v-toolbar-title class="app-bar-title font-size-small">
         {{ appBarTitle }}
@@ -45,7 +42,7 @@
 </template>
 
 <script>
-import { ERROR_MESSAGE, MAP_MODE } from "@/utils/constants";
+import { ERROR_MESSAGE } from "@/utils/constants";
 
 export default {
   name: "DoranAppBar",
@@ -62,9 +59,6 @@ export default {
     backButton() {
       return this.$store.getters["appBar/backButton"];
     },
-    cancelButton() {
-      return this.$store.getters["appBar/cancelButton"];
-    },
     appBarTitle() {
       return this.$store.getters["appBar/title"];
     },
@@ -78,10 +72,6 @@ export default {
     },
     goToPrevious() {
       this.$router.go(-1);
-    },
-    setMapDefault() {
-      this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
-      this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
     },
     toggleSearchInput() {
       this.isSearching = !this.isSearching;

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -31,6 +31,7 @@ import MapAssistantButtons from "@/components/map/MapAssistantButtons";
 import PeriodFilterButton from "@/components/map/filter/PeriodFilterButton";
 import TimelineModal from "@/components/timeline/TimelineModal";
 import PostModal from "@/components/post/PostModal";
+import { MAP_MODE } from "@/utils/constants";
 
 export default {
   name: "MapPage",
@@ -47,6 +48,7 @@ export default {
     return {
       isMapRendered: false,
       isInitialMember: false,
+      postCreate: this.$route.meta.postCreate,
       timeline: this.$route.meta.timeline,
       post: this.$route.meta.post,
     };
@@ -72,8 +74,14 @@ export default {
   },
   watch: {
     "$route.meta"(val) {
+      this.postCreate = val.postCreate;
       this.timeline = val.timeline;
       this.post = val.post;
+    },
+    postCreate(val) {
+      if (!val) {
+        this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
+      }
     },
   },
 };

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -51,6 +51,7 @@ export default {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
+        this.$router.push("/post-create");
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -50,12 +50,12 @@ export default {
       location: this.$kakaoMap.getCenterLocation(),
       buttonColor: DORAN_DORAN_COLORS.POINT_COLOR,
       rendered: false,
-      flag: false,
+      isTransitionDone: false,
     };
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.flag || to.path !== "/") {
+      if (this.isTransitionDone || to.path !== "/") {
         next(true);
       }
       this.rendered = false;
@@ -105,7 +105,7 @@ export default {
       this.rendered = false;
     },
     closeModal() {
-      this.flag = true;
+      this.isTransitionDone = true;
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
       this.$router.push("/");

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -50,7 +50,18 @@ export default {
       location: this.$kakaoMap.getCenterLocation(),
       buttonColor: DORAN_DORAN_COLORS.POINT_COLOR,
       rendered: false,
+      flag: false,
     };
+  },
+  created() {
+    const preventRoute = this.$router.beforeEach((to, from, next) => {
+      if (this.flag || to.path !== "/") {
+        next(true);
+      }
+      this.rendered = false;
+      next(false);
+    });
+    this.$once("hook:destroyed", preventRoute);
   },
   mounted() {
     this.rendered = true;
@@ -94,6 +105,7 @@ export default {
       this.rendered = false;
     },
     closeModal() {
+      this.flag = true;
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
       this.$router.push("/");

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -96,6 +96,7 @@ export default {
     closeModal() {
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
+      this.$router.push("/");
     },
   },
 };

--- a/front/src/components/timeline/TimelineModal.vue
+++ b/front/src/components/timeline/TimelineModal.vue
@@ -23,7 +23,7 @@ export default {
   data() {
     return {
       rendered: false,
-      flag: false,
+      isTransitionDone: false,
     };
   },
   computed: {
@@ -40,7 +40,7 @@ export default {
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.flag || to.path !== "/") {
+      if (this.isTransitionDone || to.path !== "/") {
         next(true);
       }
       this.rendered = false;
@@ -56,7 +56,7 @@ export default {
       this.rendered = false;
     },
     close() {
-      this.flag = true;
+      this.isTransitionDone = true;
       this.$router.go(-1);
     },
   },

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -18,6 +18,10 @@ const routes = [
     },
     children: [
       {
+        path: "post-create",
+        name: "PostCreate",
+      },
+      {
         path: "timeline",
         name: "TimelineModal",
         components: {

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -13,6 +13,7 @@ const routes = [
     name: "MapPage",
     component: MapPage,
     meta: {
+      postCreate: false,
       timeline: false,
       post: false,
     },
@@ -20,6 +21,9 @@ const routes = [
       {
         path: "post-create",
         name: "PostCreate",
+        meta: {
+          postCreate: true,
+        },
       },
       {
         path: "timeline",

--- a/front/src/store/modules/appBar.js
+++ b/front/src/store/modules/appBar.js
@@ -3,7 +3,6 @@ export default {
   state: {
     myPageButton: false,
     backButton: false,
-    cancelButton: false,
     title: "",
     address: "",
     searchButton: false,
@@ -16,20 +15,17 @@ export default {
     MAP_PAGE_DEFAULT_MODE(state) {
       state.myPageButton = true;
       state.backButton = false;
-      state.cancelButton = false;
       state.title = state.address;
       state.searchButton = true;
     },
     MAP_PAGE_MARKER_MODE(state) {
       state.myPageButton = false;
-      state.backButton = false;
-      state.cancelButton = true;
+      state.backButton = true;
       state.searchButton = false;
     },
     POST_DETAIL_PAGE(state) {
       state.myPageButton = false;
       state.backButton = true;
-      state.cancelButton = false;
       state.title = "게시글";
       state.searchButton = false;
     },
@@ -40,9 +36,6 @@ export default {
     },
     backButton: (state) => {
       return state.backButton;
-    },
-    cancelButton: (state) => {
-      return state.cancelButton;
     },
     searchButton: (state) => {
       return state.searchButton;


### PR DESCRIPTION
resolve #185 

/post-create 가 추가되었습니다.
이제 브라우저 내의 뒤로가기 하면 기본 화면으로 이동하며 맵의 모드가 바뀝니다.

추가적으로 처음 화면 돌입 시 "/"이 아니라 다른 경로로 들어오면 "/"로 리다이렉팅 하도록 변경했어요,