### PR TITLE
feature/231 검색창의 검색 기능을 키워드가 아닌 위치+상호 검색으로 변경한다.

### DIFF
--- a/front/src/assets/index.css
+++ b/front/src/assets/index.css
@@ -66,3 +66,10 @@ a {
 .fade-leave-active {
   opacity: 0;
 }
+
+.place-overlay-style {
+  padding-left: 7px;
+  padding-right: 7px;
+  background-color: white;
+  border-radius: 20px;
+}

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -81,7 +81,10 @@ export default {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_KEYWORD_INPUT);
         return;
       }
-      this.$kakaoMap.searchPlace(this.keyword);
+      this.$kakaoMap.searchPlace(this.keyword, this.searchFail);
+    },
+    searchFail() {
+      this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_SEARCH_RESULT_MESSAGE);
     },
     async filterPosts() {
       if (this.keyword === "") {

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -86,8 +86,12 @@ export default {
       }
       this.$kakaoMap.searchPlace(this.keyword, this.searchFail);
     },
-    searchFail() {
-      this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_SEARCH_RESULT_MESSAGE);
+    searchFail(errorMessage) {
+      if (errorMessage === "ZERO_RESULT") {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_SEARCH_RESULT_MESSAGE);
+      } else if (errorMessage === "ERROR") {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.EXECUTION_ERROR);
+      }
     },
     async filterPosts() {
       if (this.keyword === "") {
@@ -114,8 +118,8 @@ export default {
       if (!this.searchButton) {
         this.hideSearchInput();
       }
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -1,7 +1,6 @@
 <template>
   <v-app-bar flat max-height="56" color="white">
     <v-container
-      v-show="isSearching"
       fluid
       class="d-flex flex-row align-center justify-space-between pa-0"
     >
@@ -76,6 +75,10 @@ export default {
     toggleSearchInput() {
       this.isSearching = !this.isSearching;
     },
+    hideSearchInput() {
+      this.isSearching = false;
+      this.keyword = "";
+    },
     searchPlace() {
       if (this.keyword === "") {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_KEYWORD_INPUT);
@@ -100,14 +103,19 @@ export default {
         );
       }
     },
-    async initializeMapPage() {
+    initializeMapPage() {
       this.toggleSearchInput();
       this.keyword = "";
       this.$kakaoMap.clearPlaceMarkers();
-      this.$store.commit("post/filter/SET_KEYWORD", "");
-      await this.$store.dispatch("post/loadPosts");
     },
   },
+  watch: {
+    searchButton() {
+      if (!this.searchButton) {
+        this.hideSearchInput();
+      }
+    }
+  }
 };
 </script>
 

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -103,6 +103,7 @@ export default {
     async initializeMapPage() {
       this.toggleSearchInput();
       this.keyword = "";
+      this.$kakaoMap.clearPlaceMarkers();
       this.$store.commit("post/filter/SET_KEYWORD", "");
       await this.$store.dispatch("post/loadPosts");
     },

--- a/front/src/components/DoranAppBar.vue
+++ b/front/src/components/DoranAppBar.vue
@@ -34,7 +34,7 @@
         hide-details
         append-outer-icon="mdi-window-close"
         class="search-input font-size-small"
-        @keypress.enter="filterPosts"
+        @keypress.enter="searchPlace"
         @click:append-outer="initializeMapPage"
       />
     </v-expand-x-transition>
@@ -75,6 +75,13 @@ export default {
     },
     toggleSearchInput() {
       this.isSearching = !this.isSearching;
+    },
+    searchPlace() {
+      if (this.keyword === "") {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.NO_KEYWORD_INPUT);
+        return;
+      }
+      this.$kakaoMap.searchPlace(this.keyword);
     },
     async filterPosts() {
       if (this.keyword === "") {

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -51,7 +51,7 @@ export default {
       EVENT_TYPE.CENTER_CHANGE,
       this.changeAppBarByCenterAddress,
     );
-    await this.$kakaoMap.initPlaceSearch();
+    this.$kakaoMap.initPlaceSearch();
     this.isMapRendered = true;
     this.$emit("render");
   },

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -51,6 +51,7 @@ export default {
       EVENT_TYPE.CENTER_CHANGE,
       this.changeAppBarByCenterAddress,
     );
+    await this.$kakaoMap.initPlaceSearch();
     this.isMapRendered = true;
     this.$emit("render");
   },

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -51,7 +51,6 @@ export default {
       EVENT_TYPE.CENTER_CHANGE,
       this.changeAppBarByCenterAddress,
     );
-    this.$kakaoMap.initPlaceSearch();
     this.isMapRendered = true;
     this.$emit("render");
   },

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -51,6 +51,7 @@ export default {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.MARKER);
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
+        this.$kakaoMap.clearPlaceMarkers();
         this.$router.push("/post-create");
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -1,5 +1,6 @@
 import { KAKAO_MAP_APP_KEY } from "@/secure/appkey";
 import { EVENT_TYPE } from "@/utils/constants";
+import { PLACE_OVERLAY_TEMPLATE } from "@/utils/templates";
 
 const KAKAO_MAP_URL = "//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=";
 const LIBRARY = "&libraries=services,clusterer";
@@ -278,9 +279,7 @@ export const KakaoMap = (() => {
 
   const _setPlaceOverlay = (name, location) => {
     if (!placeOverlay.getMap()) {
-      placeOverlay.setContent(
-        `<div class='place-overlay-style font-size-x-small'>${name}</div>`,
-      );
+      placeOverlay.setContent(PLACE_OVERLAY_TEMPLATE(name));
       placeOverlay.setPosition(_createKakaoLocation(location));
       placeOverlay.setMap(map);
     } else {

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -165,34 +165,29 @@ export const KakaoMap = (() => {
     map.setCenter(targetLocation);
   };
 
-  const _createMarkerImage = (src, size, options) => {
-    return new kakao.maps.MarkerImage(src, size, options);
+  const _createMarkerImage = (img, size, options) => {
+    if (!img) {
+      return null;
+    }
+    return new kakao.maps.MarkerImage(img, size, options);
   };
 
   const _createMarker = (map, position, image) => {
-    const newMarker = new kakao.maps.Marker({
+    return new kakao.maps.Marker({
       map: map,
       position: position,
       image: image,
     });
-    return newMarker;
   };
 
-  const setMarker = (location) => {
-    if (!map || !location) {
-      return;
-    }
-    const kakaoLocation = _createKakaoLocation(location);
-    return _createMarker(map, kakaoLocation, null);
-  };
-
-  const setMarkerWithImage = (location, img) => {
+  const setMarker = (location, img) => {
     if (!map || !location) {
       return;
     }
     const kakaoLocation = _createKakaoLocation(location);
     const markerSize = new kakao.maps.Size(36, 36);
     const markerImage = _createMarkerImage(img, markerSize);
+
     return _createMarker(map, kakaoLocation, markerImage);
   };
 
@@ -203,7 +198,7 @@ export const KakaoMap = (() => {
     const currentLocation = await getCurrentLocation();
     setCenterLocation(currentLocation);
     if (!marker) {
-      marker = setMarkerWithImage(currentLocation, CURRENT_MARKER_IMAGE);
+      marker = setMarker(currentLocation, CURRENT_MARKER_IMAGE);
     } else {
       marker.setPosition(_createKakaoLocation(currentLocation));
     }
@@ -359,7 +354,7 @@ export const KakaoMap = (() => {
     getCenterLocation,
     setCenterLocation,
     setCenterByCurrentLocation,
-    setMarker: setMarkerWithImage,
+    setMarker,
     getBounds,
     setPostOverlay,
     hidePostOverlays,

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -44,7 +44,9 @@ export const KakaoMap = (() => {
   };
 
   const _createPlaceOverlay = () => {
-    return new kakao.maps.CustomOverlay({});
+    return new kakao.maps.CustomOverlay({
+      yAnchor: 3.2,
+    });
   };
 
   const _createClusterer = () => {
@@ -300,7 +302,9 @@ export const KakaoMap = (() => {
 
     kakao.maps.event.addListener(marker, EVENT_TYPE.CLICK, function () {
       placeOverlay.setContent(
-        "<div>" + place.place_name + "</div>",
+        "<div class='place-overlay-style font-size-x-small'>" +
+          place.place_name +
+          "</div>",
       );
       placeOverlay.setPosition(new kakao.maps.LatLng(place.y, place.x));
       placeOverlay.setMap(map);

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -119,6 +119,7 @@ export const KakaoMap = (() => {
     map = new kakao.maps.Map(mapContainer, options);
     postOverlays = [];
     clusterer = _createClusterer();
+    _initPlaceSearch();
 
     return map;
   };
@@ -255,7 +256,7 @@ export const KakaoMap = (() => {
     postOverlays = [];
   };
 
-  const initPlaceSearch = () => {
+  const _initPlaceSearch = () => {
     places = _createPlaces();
     placeOverlay = _createPlaceOverlay();
   };
@@ -310,7 +311,7 @@ export const KakaoMap = (() => {
     if (placeMarkers.length !== 0) {
       placeMarkers.forEach((marker) => marker.setMap(null));
     }
-    if (placeOverlay.getMap !== null) {
+    if (placeOverlay.getMap()) {
       placeOverlay.setMap(null);
     }
     placeMarkers = [];
@@ -359,7 +360,6 @@ export const KakaoMap = (() => {
     showPostOverlays,
     clearClusterer,
     clearPostOverlay,
-    initPlaceSearch,
     searchPlace,
     clearPlaceMarkers,
     getAddress,

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -257,11 +257,19 @@ export const KakaoMap = (() => {
     places = _createPlaces();
   };
 
-  const searchPlace = (place) => {
-    places.keywordSearch(place, _searchPlaceCallBack);
+  const searchPlace = (place, reject) => {
+    places.keywordSearch(place, (data, status) =>
+      _searchPlaceCallBack(data, status, reject),
+    );
   };
 
-  const _searchPlaceCallBack = (data, status) => {
+  const _searchPlaceCallBack = (data, status, reject) => {
+    if (status === kakao.maps.services.Status.ZERO_RESULT) {
+      const error = new Error(
+        kakao.maps.services.Status.ZERO_RESULT + " - there's no result",
+      );
+      reject(error);
+    }
     if (status === kakao.maps.services.Status.OK) {
       const bounds = new kakao.maps.LatLngBounds();
 

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -38,7 +38,7 @@ export const KakaoMap = (() => {
   };
 
   const _createPlaces = () => {
-    return new kakao.maps.service.Places();
+    return new kakao.maps.services.Places();
   };
 
   const _createClusterer = () => {
@@ -253,15 +253,15 @@ export const KakaoMap = (() => {
   };
 
   const initPlaceSearch = () => {
-    _createInfoWindow();
-    _createPlaces();
+    infoWindow = _createInfoWindow();
+    places = _createPlaces();
   };
 
-  const placeSearch = (location) => {
-    places.keywordSearch(location, _placeSearchCallBack);
+  const searchPlace = (place) => {
+    places.keywordSearch(place, _searchPlaceCallBack);
   };
 
-  const _placeSearchCallBack = (data, status) => {
+  const _searchPlaceCallBack = (data, status) => {
     if (status === kakao.maps.services.Status.OK) {
       const bounds = new kakao.maps.LatLngBounds();
 
@@ -275,9 +275,9 @@ export const KakaoMap = (() => {
   };
 
   function displayMarker(place) {
-    const marker = new kakao.mapsMarker({
+    const marker = new kakao.maps.Marker({
       map: map,
-      position: new kakao.map.LatLng(place.y, place.x),
+      position: new kakao.maps.LatLng(place.y, place.x),
     });
 
     kakao.maps.event.addListener(marker, EVENT_TYPE.CLICK, function () {
@@ -332,7 +332,7 @@ export const KakaoMap = (() => {
     clearClusterer,
     clearPostOverlay,
     initPlaceSearch,
-    placeSearch,
+    searchPlace,
     getAddress,
     addEventToMap,
     setMap,

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -15,6 +15,7 @@ const CURRENT_MARKER_IMAGE =
 export const KakaoMap = (() => {
   let map = null;
   let postOverlays = [];
+  let placeMarkers = [];
   let clusterer = null;
   let marker = null;
   let infoWindow = null;
@@ -258,6 +259,8 @@ export const KakaoMap = (() => {
   };
 
   const searchPlace = (place, reject) => {
+    clearPlaceMarkers();
+
     places.keywordSearch(place, (data, status) =>
       _searchPlaceCallBack(data, status, reject),
     );
@@ -274,7 +277,7 @@ export const KakaoMap = (() => {
       const bounds = new kakao.maps.LatLngBounds();
 
       for (let i = 0; i < data.length; i++) {
-        displayMarker(data[i]);
+        _displayMarker(data[i]);
         bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
       }
 
@@ -282,11 +285,13 @@ export const KakaoMap = (() => {
     }
   };
 
-  function displayMarker(place) {
+  const _displayMarker = (place) => {
     const marker = new kakao.maps.Marker({
       map: map,
       position: new kakao.maps.LatLng(place.y, place.x),
     });
+
+    placeMarkers.push(marker);
 
     kakao.maps.event.addListener(marker, EVENT_TYPE.CLICK, function () {
       infoWindow.setContent(
@@ -294,7 +299,18 @@ export const KakaoMap = (() => {
       );
       infoWindow.open(map, marker);
     });
-  }
+  };
+
+  const clearPlaceMarkers = () => {
+    if (placeMarkers.length !== 0) {
+      placeMarkers.forEach((marker) => marker.setMap(null));
+    }
+    if (infoWindow !== null) {
+      infoWindow.close();
+    }
+    placeMarkers = [];
+    infoWindow = _createInfoWindow();
+  };
 
   const _getAdministrativeAddress = (location) => {
     const geocoder = new kakao.maps.services.Geocoder();
@@ -341,6 +357,7 @@ export const KakaoMap = (() => {
     clearPostOverlay,
     initPlaceSearch,
     searchPlace,
+    clearPlaceMarkers,
     getAddress,
     addEventToMap,
     setMap,

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -16,6 +16,7 @@ export const KakaoMap = (() => {
   let map = null;
   let postOverlays = [];
   let placeMarkers = [];
+  let placeOverlay = null;
   let clusterer = null;
   let marker = null;
   let infoWindow = null;
@@ -40,6 +41,10 @@ export const KakaoMap = (() => {
 
   const _createPlaces = () => {
     return new kakao.maps.services.Places();
+  };
+
+  const _createPlaceOverlay = () => {
+    return new kakao.maps.CustomOverlay({});
   };
 
   const _createClusterer = () => {
@@ -254,8 +259,8 @@ export const KakaoMap = (() => {
   };
 
   const initPlaceSearch = () => {
-    infoWindow = _createInfoWindow();
     places = _createPlaces();
+    placeOverlay = _createPlaceOverlay();
   };
 
   const searchPlace = (place, reject) => {
@@ -294,10 +299,11 @@ export const KakaoMap = (() => {
     placeMarkers.push(marker);
 
     kakao.maps.event.addListener(marker, EVENT_TYPE.CLICK, function () {
-      infoWindow.setContent(
-        '<div style="font-size:12px;">' + place.place_name + "</div>",
+      placeOverlay.setContent(
+        "<div>" + place.place_name + "</div>",
       );
-      infoWindow.open(map, marker);
+      placeOverlay.setPosition(new kakao.maps.LatLng(place.y, place.x));
+      placeOverlay.setMap(map);
     });
   };
 
@@ -305,11 +311,10 @@ export const KakaoMap = (() => {
     if (placeMarkers.length !== 0) {
       placeMarkers.forEach((marker) => marker.setMap(null));
     }
-    if (infoWindow !== null) {
-      infoWindow.close();
+    if (placeOverlay.getMap !== null) {
+      placeOverlay.setMap(null);
     }
     placeMarkers = [];
-    infoWindow = _createInfoWindow();
   };
 
   const _getAdministrativeAddress = (location) => {

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -19,7 +19,6 @@ export const KakaoMap = (() => {
   let placeOverlay = null;
   let clusterer = null;
   let marker = null;
-  let infoWindow = null;
   let places = null;
 
   const script = document.createElement("script");
@@ -33,10 +32,6 @@ export const KakaoMap = (() => {
 
   const _createKakaoLocation = (location) => {
     return new kakao.maps.LatLng(location.latitude, location.longitude);
-  };
-
-  const _createInfoWindow = () => {
-    return new kakao.maps.InfoWindow({ zIndex: 1 });
   };
 
   const _createPlaces = () => {

--- a/front/src/plugins/kakao-map.js
+++ b/front/src/plugins/kakao-map.js
@@ -303,8 +303,7 @@ export const KakaoMap = (() => {
       data.forEach((place) => _setPlaceMarker(place, bounds));
       map.setBounds(bounds);
     } else {
-      reject();
-      throw new Error(status);
+      reject(status);
     }
   };
 

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -4,6 +4,7 @@ const ERROR_MESSAGE = {
   NO_POST_MESSAGE: "😭 해당 기간에 글이 존재하지 않습니다.",
   NO_KEYWORD_INPUT: "🧐 키워드를 입력해주세요.",
   NO_SEARCH_RESULT_MESSAGE: "😭 해당 키워드의 검색 결과가 없습니다.",
+  EXECUTION_ERROR: "😭 에러가 발생했습니다.",
   INVALID_USER_DATE_INPUT: "😨 시작 날짜는 종료 날짜보다 뒤일 수 없습니다.",
   LOGIN_REQUIRED: "🔑 로그인이 필요해요.",
 };

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -14,6 +14,7 @@ const API_BASE_URL = {
 
 const EVENT_TYPE = {
   CENTER_CHANGE: "center_changed",
+  CLICK: "click",
 };
 
 const MAP_MODE = {

--- a/front/src/utils/templates.js
+++ b/front/src/utils/templates.js
@@ -1,0 +1,4 @@
+const PLACE_OVERLAY_TEMPLATE = (name) =>
+  `<div class='place-overlay-style font-size-x-small'>${name}</div>`;
+
+export { PLACE_OVERLAY_TEMPLATE };


### PR DESCRIPTION
Resolves #231 

사용자 피드백을 반영해 검색창의 검색을 "위치", "상호" 검색으로 변경합니다.

이제 검색창에서 지역 이름이나 상호명을 검색하면 해당 검색 결과가 있는 지역으로 이동합니다.
마커를 클릭하면 상세 상호명을 확인할 수 있습니다.

검색 결과가 없는 경우의 예외 처리도 구현되어 있습니다.