### PR TITLE
feature/239 N+1 문제를 해결한다.

### DIFF
--- a/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
@@ -24,9 +24,12 @@ public class PostRepositorySupport extends QuerydslRepositorySupport {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
+    //둘이 fetchjoin은 됨. 다만 comment가 중복으로 생기는 문제 (카테시안곱) 발생.
     public List<Post> findPostWithKeywordAndDate(String keyword, LocalDateTime startDate, LocalDateTime endDate) {
         List<Post> persistPosts = jpaQueryFactory.selectFrom(post)
             .distinct()
+            .leftJoin(post.comments).fetchJoin()
+            .leftJoin(post.likes)
             .where(isPostAlive())
             .where(containsKeyword(keyword), betweenDate(startDate, endDate))
             .fetch();

--- a/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/repository/PostRepositorySupport.java
@@ -24,7 +24,6 @@ public class PostRepositorySupport extends QuerydslRepositorySupport {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    //둘이 fetchjoin은 됨. 다만 comment가 중복으로 생기는 문제 (카테시안곱) 발생.
     public List<Post> findPostWithKeywordAndDate(String keyword, LocalDateTime startDate, LocalDateTime endDate) {
         List<Post> persistPosts = jpaQueryFactory.selectFrom(post)
             .distinct()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:h2:mem:dorandb;IFEXISTS=FALSE;
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.properties.hibernate.default_batch_fetch_size=1000
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
 cors.url=*
 oauth2.success.redirect.url=//localhost:8081?token=
 spring.profiles.include=security

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.datasource.url=jdbc:h2:mem:dorandb;IFEXISTS=FALSE;
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.default_batch_fetch_size=1000
 cors.url=*
 oauth2.success.redirect.url=//localhost:8081?token=
 spring.profiles.include=security

--- a/src/test/java/com/grasshouse/dorandoran/post/service/PostFilterServiceTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/post/service/PostFilterServiceTest.java
@@ -1,11 +1,25 @@
 package com.grasshouse.dorandoran.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.grasshouse.dorandoran.comment.domain.Comment;
+import com.grasshouse.dorandoran.comment.repository.CommentRepository;
+import com.grasshouse.dorandoran.fixture.AddressFixture;
+import com.grasshouse.dorandoran.fixture.LocationFixture;
+import com.grasshouse.dorandoran.member.domain.Member;
+import com.grasshouse.dorandoran.member.repository.MemberRepository;
+import com.grasshouse.dorandoran.post.domain.Post;
+import com.grasshouse.dorandoran.post.domain.PostLike;
 import com.grasshouse.dorandoran.post.dto.PostFilterRequest;
+import com.grasshouse.dorandoran.post.dto.PostResponse;
+import com.grasshouse.dorandoran.post.repository.PostLikeRepository;
+import com.grasshouse.dorandoran.post.repository.PostRepository;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,6 +32,21 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
 @SpringBootTest
 class PostFilterServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PostLikeRepository postLikeRepository;
+
+    @Autowired
+    private PostFilterService postFilterService;
 
     @Autowired
     private PostFilterService PostFilterService;
@@ -52,7 +81,74 @@ class PostFilterServiceTest {
             .hasSize(searchResult);
     }
 
+    @DisplayName("post.comments, post.likes를 잘 가져오는지 테스트")
+    @Test
+    void findPostWithKeywordAndDate() {
+        Member member1 = SAVE_MEMBER("멤버1", "oAuthId1");
+        Member member2 = SAVE_MEMBER("멤버2", "oAuthId2");
+        Post post = SAVE_POST(member1);
+        SAVE_COMMENT(member1, post, "댓글1");
+        SAVE_COMMENT(member1, post, "댓글2");
+        SAVE_POST_LIKE(member1.getId(), post);
+        SAVE_POST_LIKE(member2.getId(), post);
+
+        PostFilterRequest request = new PostFilterRequest(null, null, null);
+        List<PostResponse> postResponses = postFilterService.showFilteredPosts(request);
+
+        assertThat(postResponses).hasSize(1);
+        assertAll(
+            () -> {
+                assertThat(postResponses.get(0).getComments()).hasSize(2);
+                assertThat(postResponses.get(0).getLikes()).hasSize(2);
+            }
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        commentRepository.deleteAll();
+        postRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
     private static LocalDateTime toDate(String value) {
         return LocalDateTime.parse(value, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    private Member SAVE_MEMBER(String nickname, String oAuthId) {
+        Member member = Member.builder()
+            .nickname(nickname)
+            .oAuthId(oAuthId)
+            .build();
+        return memberRepository.save(member);
+    }
+
+    private Post SAVE_POST(Member member) {
+        Post post = Post.builder()
+            .content("글")
+            .location(LocationFixture.JAMSIL_STATION)
+            .author(member)
+            .address(AddressFixture.ADDRESS)
+            .authorAddress(AddressFixture.AUTHOR_ADDRESS).build();
+        return postRepository.save(post);
+    }
+
+    private Comment SAVE_COMMENT(Member member, Post post, String content) {
+        Comment comment = Comment.builder()
+            .author(member)
+            .post(post)
+            .content(content)
+            .distance(0.0)
+            .build();
+        post.addComment(comment);
+        return commentRepository.save(comment);
+    }
+
+    private PostLike SAVE_POST_LIKE(Long memberId, Post post) {
+        PostLike postLike = PostLike.builder()
+            .memberId(memberId)
+            .post(post)
+            .build();
+        return postLikeRepository.save(postLike);
     }
 }


### PR DESCRIPTION
Resolves #239 

기존에 QueryDSL에서 발생하던 N+1 문제를 해결했습니다.
간단히 요약하면 `fetch join` 과 `default_batch_fetch_size`를 사용했구요,

관련된 설명은 [위키](https://github.com/woowacourse-teams/2020-doran-doran/wiki/%EC%97%AC%EB%9F%AC-%EA%B0%9C%EC%9D%98-%EC%BB%AC%EB%A0%89%EC%85%98%EC%9D%84-FetchJoin-%EC%8B%9C-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94)를 참고해주세요! 🙂 