### PR TITLE
hotfix/241 닉네임 업데이트 관련 테스트를 수정한다.

### DIFF
--- a/src/test/java/com/grasshouse/dorandoran/member/service/MemberServiceTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/member/service/MemberServiceTest.java
@@ -50,7 +50,7 @@ class MemberServiceTest {
     @DisplayName("사용자의 닉네임을 업데이트한다.")
     @Test
     void update() {
-        MemberUpdateRequest request = new MemberUpdateRequest("new nickname");
+        MemberUpdateRequest request = new MemberUpdateRequest("NewNickname");
 
         MemberUpdateResponse response = memberService.update(member, request);
 


### PR DESCRIPTION
Resolves #241 

기존 백엔드 테스트에 깨지는 부분이 있었네요 😂 (닉네임 업데이트하는 설정값에 띄어쓰기 포함)
해결하는 PR입니다.