### PR TITLE
feature/243 라우터 이동을 위한 객체들을 별도로 관리한다.

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -60,14 +60,14 @@ export default {
       const isNotMapPage = this.$route.name !== this.$pages.map.name;
       const isNotPostModal = this.$route.name !== this.$pages.post().name;
       if (isNotMapPage && isNotPostModal) {
-        this.$router.push(this.$pages.map.path);
+        this.$router.push(this.$pages.map);
       }
     },
     checkUrlToken() {
       const urlToken = location.href.split("token=")[1];
       if (urlToken) {
         localStorage.setItem("accessToken", urlToken);
-        this.$router.push(this.$pages.map.path);
+        this.$router.push(this.$pages.map);
       }
     },
     async checkToken() {
@@ -75,7 +75,7 @@ export default {
       if (storageToken && storageToken !== "guest") {
         await this.$store.dispatch("member/loadMember");
       } else if (!storageToken) {
-        await this.$router.push(this.$pages.login.path);
+        await this.$router.push(this.$pages.login);
       }
     },
     preventRoute() {

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,17 +57,17 @@ export default {
   },
   methods: {
     checkUrl() {
-      const isNotMapPage = this.$route.name !== this.$pages.map.name;
+      const isNotMapPage = this.$route.name !== this.$pages.map().name;
       const isNotPostModal = this.$route.name !== this.$pages.post().name;
       if (isNotMapPage && isNotPostModal) {
-        this.$router.push(this.$pages.map);
+        this.$router.push(this.$pages.map());
       }
     },
     checkUrlToken() {
       const urlToken = location.href.split("token=")[1];
       if (urlToken) {
         localStorage.setItem("accessToken", urlToken);
-        this.$router.push(this.$pages.map);
+        this.$router.push(this.$pages.map());
       }
     },
     async checkToken() {
@@ -75,12 +75,12 @@ export default {
       if (storageToken && storageToken !== "guest") {
         await this.$store.dispatch("member/loadMember");
       } else if (!storageToken) {
-        await this.$router.push(this.$pages.login);
+        await this.$router.push(this.$pages.login());
       }
     },
     preventRoute() {
       this.$router.beforeEach(async (to, from, next) => {
-        if (to.path === this.$pages.map.path || to.path === this.$pages.timeline.path) {
+        if (to.path === this.$pages.map().path || to.path === this.$pages.timeline().path) {
           this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
           await this.$store.dispatch("post/loadPosts");
         }

--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -57,17 +57,17 @@ export default {
   },
   methods: {
     checkUrl() {
-      const isNotMapPage = this.$route.name !== "MapPage";
-      const isNotPostModal = this.$route.name !== "PostModal";
+      const isNotMapPage = this.$route.name !== this.$pages.map.name;
+      const isNotPostModal = this.$route.name !== this.$pages.post().name;
       if (isNotMapPage && isNotPostModal) {
-        this.$router.push("/");
+        this.$router.push(this.$pages.map.path);
       }
     },
     checkUrlToken() {
       const urlToken = location.href.split("token=")[1];
       if (urlToken) {
         localStorage.setItem("accessToken", urlToken);
-        location.href = "/";
+        this.$router.push(this.$pages.map.path);
       }
     },
     async checkToken() {
@@ -75,12 +75,12 @@ export default {
       if (storageToken && storageToken !== "guest") {
         await this.$store.dispatch("member/loadMember");
       } else if (!storageToken) {
-        await this.$router.push("/login");
+        await this.$router.push(this.$pages.login.path);
       }
     },
     preventRoute() {
       this.$router.beforeEach(async (to, from, next) => {
-        if (to.path === "/" || to.path === "/timeline") {
+        if (to.path === this.$pages.map.path || to.path === this.$pages.timeline.path) {
           this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
           await this.$store.dispatch("post/loadPosts");
         }

--- a/front/src/components/login/LoginPage.vue
+++ b/front/src/components/login/LoginPage.vue
@@ -22,7 +22,7 @@ export default {
   methods: {
     guest() {
       localStorage.setItem("accessToken", "guest");
-      this.$router.push(this.$pages.map);
+      this.$router.push(this.$pages.map());
     },
     kakaoLogin() {
       window.location.href = API_BASE_URL.EC2 + "/oauth2/authorization/kakao";

--- a/front/src/components/login/LoginPage.vue
+++ b/front/src/components/login/LoginPage.vue
@@ -22,7 +22,7 @@ export default {
   methods: {
     guest() {
       localStorage.setItem("accessToken", "guest");
-      this.$router.push("/");
+      this.$router.push(this.$pages.map);
     },
     kakaoLogin() {
       window.location.href = API_BASE_URL.EC2 + "/oauth2/authorization/kakao";

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -6,7 +6,7 @@
       <PeriodFilterButton v-show="isDefaultMode" />
       <router-link
         v-show="isDefaultMode"
-        :to="this.$pages.timeline"
+        :to="this.$pages.timeline()"
         class="px-3 font-size-x-small timeline-btn"
       >
         <v-icon color="black" class="mb-1" small>

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -6,7 +6,7 @@
       <PeriodFilterButton v-show="isDefaultMode" />
       <router-link
         v-show="isDefaultMode"
-        to="/timeline"
+        :to="this.$pages.timeline"
         class="px-3 font-size-x-small timeline-btn"
       >
         <v-icon color="black" class="mb-1" small>

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -52,7 +52,7 @@ export default {
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
         this.$kakaoMap.clearPlaceMarkers();
-        this.$router.push(this.$pages.postCreate);
+        this.$router.push(this.$pages.postCreate());
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }

--- a/front/src/components/map/PostCreateButton.vue
+++ b/front/src/components/map/PostCreateButton.vue
@@ -52,7 +52,7 @@ export default {
         this.$store.commit("snackbar/SHOW", MARKER_MODE_MESSAGE);
         this.$store.commit("appBar/MAP_PAGE_MARKER_MODE");
         this.$kakaoMap.clearPlaceMarkers();
-        this.$router.push("/post-create");
+        this.$router.push(this.$pages.postCreate);
       } else if (this.isMarkerMode) {
         this.$store.commit("map/CHANGE_MODE", MAP_MODE.POST);
       }

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -55,7 +55,7 @@ export default {
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.isTransitionDone || to.path !== "/") {
+      if (this.isTransitionDone || to.path !== this.$pages.map.path) {
         next(true);
       }
       this.rendered = false;
@@ -108,7 +108,7 @@ export default {
       this.isTransitionDone = true;
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
-      this.$router.push("/");
+      this.$router.push(this.$pages.map);
     },
   },
 };

--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -55,7 +55,7 @@ export default {
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.isTransitionDone || to.path !== this.$pages.map.path) {
+      if (this.isTransitionDone || to.path !== this.$pages.map().path) {
         next(true);
       }
       this.rendered = false;
@@ -108,7 +108,7 @@ export default {
       this.isTransitionDone = true;
       this.$store.commit("map/CHANGE_MODE", MAP_MODE.DEFAULT);
       this.$store.commit("appBar/MAP_PAGE_DEFAULT_MODE");
-      this.$router.push(this.$pages.map);
+      this.$router.push(this.$pages.map());
     },
   },
 };

--- a/front/src/components/map/PostOverlay.vue
+++ b/front/src/components/map/PostOverlay.vue
@@ -46,7 +46,7 @@ export default {
   },
   methods: {
     openPostModal() {
-      this.$router.push("posts/" + this.post.id);
+      this.$router.push(this.$pages.post(this.post.id));
     },
   },
   watch: {

--- a/front/src/components/member/MemberSidebar.vue
+++ b/front/src/components/member/MemberSidebar.vue
@@ -117,7 +117,7 @@ export default {
     logout() {
       this.$store.commit("member/SET_LOGOUT_MEMBER");
       this.$store.commit("snackbar/SHOW", LOGOUT_SUCCESS_MESSAGE);
-      this.$router.push("/login");
+      this.$router.push(this.$pages.login);
     },
     openMemberDeleteDialog() {
       this.isDeleting = true;
@@ -135,7 +135,7 @@ export default {
       if (this.isDeleting) {
         this.$store.commit("member/SET_LOGOUT_MEMBER");
         this.$store.commit("snackbar/SHOW", DELETE_MEMBER_SUCCESS);
-        await this.$router.push("/login");
+        await this.$router.push(this.$pages.login);
         this.closeMemberDeleteDialog();
       }
     },

--- a/front/src/components/member/MemberSidebar.vue
+++ b/front/src/components/member/MemberSidebar.vue
@@ -117,7 +117,7 @@ export default {
     logout() {
       this.$store.commit("member/SET_LOGOUT_MEMBER");
       this.$store.commit("snackbar/SHOW", LOGOUT_SUCCESS_MESSAGE);
-      this.$router.push(this.$pages.login);
+      this.$router.push(this.$pages.login());
     },
     openMemberDeleteDialog() {
       this.isDeleting = true;
@@ -135,7 +135,7 @@ export default {
       if (this.isDeleting) {
         this.$store.commit("member/SET_LOGOUT_MEMBER");
         this.$store.commit("snackbar/SHOW", DELETE_MEMBER_SUCCESS);
-        await this.$router.push(this.$pages.login);
+        await this.$router.push(this.$pages.login());
         this.closeMemberDeleteDialog();
       }
     },

--- a/front/src/components/timeline/PostItem.vue
+++ b/front/src/components/timeline/PostItem.vue
@@ -42,7 +42,7 @@ export default {
   },
   methods: {
     openPostModal() {
-      this.$router.push("posts/" + this.post.id);
+      this.$router.push(this.$pages.post(this.post.id));
     },
     hasLike(like) {
       return (

--- a/front/src/components/timeline/TimelineModal.vue
+++ b/front/src/components/timeline/TimelineModal.vue
@@ -40,7 +40,7 @@ export default {
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.isTransitionDone || to.path !== this.$pages.map.path) {
+      if (this.isTransitionDone || to.path !== this.$pages.map().path) {
         next(true);
       }
       this.rendered = false;

--- a/front/src/components/timeline/TimelineModal.vue
+++ b/front/src/components/timeline/TimelineModal.vue
@@ -40,7 +40,7 @@ export default {
   },
   created() {
     const preventRoute = this.$router.beforeEach((to, from, next) => {
-      if (this.isTransitionDone || to.path !== "/") {
+      if (this.isTransitionDone || to.path !== this.$pages.map.path) {
         next(true);
       }
       this.rendered = false;

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -4,6 +4,7 @@ import router from "@/router";
 import store from "@/store";
 import vuetify from "@/plugins/vuetify";
 import KakaoMap from "@/plugins/kakao-map";
+import pages from "@/plugins/doran-pages";
 import VueAnalytics from "vue-analytics";
 import LogRocket from "logrocket";
 import {
@@ -20,6 +21,7 @@ LogRocket.init(LOGROCKET_APP_ID);
 
 Vue.config.productionTip = false;
 Vue.use(KakaoMap);
+Vue.use(pages);
 
 const moment = require("moment");
 require("moment/locale/ko");

--- a/front/src/plugins/doran-pages.js
+++ b/front/src/plugins/doran-pages.js
@@ -1,15 +1,21 @@
 export const pages = {
-  map: {
-    path: "/",
-    name: "Map",
+  map: () => {
+    return {
+      path: "/",
+      name: "Map",
+    };
   },
-  postCreate: {
-    path: "/post-create",
-    name: "PostCreate",
+  postCreate: () => {
+    return {
+      path: "/post-create",
+      name: "PostCreate",
+    };
   },
-  timeline: {
-    path: "/timeline",
-    name: "Timeline",
+  timeline: () => {
+    return {
+      path: "/timeline",
+      name: "Timeline",
+    };
   },
   post: (id) => {
     return {
@@ -20,9 +26,11 @@ export const pages = {
       },
     };
   },
-  login: {
-    path: "/login",
-    name: "Login",
+  login: () => {
+    return {
+      path: "/login",
+      name: "Login",
+    };
   },
 };
 

--- a/front/src/plugins/doran-pages.js
+++ b/front/src/plugins/doran-pages.js
@@ -1,0 +1,33 @@
+export const pages = {
+  map: {
+    path: "/",
+    name: "Map",
+  },
+  postCreate: {
+    path: "/post-create",
+    name: "PostCreate",
+  },
+  timeline: {
+    path: "/timeline",
+    name: "Timeline",
+  },
+  post: (id) => {
+    return {
+      path: "/posts/" + id,
+      name: "Post",
+      params: {
+        id,
+      },
+    };
+  },
+  login: {
+    path: "/login",
+    name: "Login",
+  },
+};
+
+export default {
+  install(Vue) {
+    Vue.prototype.$pages = pages;
+  },
+};

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -10,7 +10,7 @@ Vue.use(VueRouter);
 
 const routes = [
   {
-    ...pages.map,
+    ...pages.map(),
     component: MapPage,
     meta: {
       postCreate: false,
@@ -19,13 +19,13 @@ const routes = [
     },
     children: [
       {
-        ...pages.postCreate,
+        ...pages.postCreate(),
         meta: {
           postCreate: true,
         },
       },
       {
-        ...pages.timeline,
+        ...pages.timeline(),
         components: {
           page: TimelineModal,
         },
@@ -45,7 +45,7 @@ const routes = [
     ],
   },
   {
-    ...pages.login,
+    ...pages.login(),
     component: LoginPage,
   },
 ];

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -4,13 +4,13 @@ import LoginPage from "@/components/login/LoginPage";
 import MapPage from "@/components/map/MapPage";
 import TimelineModal from "@/components/timeline/TimelineModal";
 import PostModal from "@/components/post/PostModal";
+import { pages } from "@/plugins/doran-pages";
 
 Vue.use(VueRouter);
 
 const routes = [
   {
-    path: "/",
-    name: "MapPage",
+    ...pages.map,
     component: MapPage,
     meta: {
       postCreate: false,
@@ -19,15 +19,13 @@ const routes = [
     },
     children: [
       {
-        path: "post-create",
-        name: "PostCreate",
+        ...pages.postCreate,
         meta: {
           postCreate: true,
         },
       },
       {
-        path: "timeline",
-        name: "TimelineModal",
+        ...pages.timeline,
         components: {
           page: TimelineModal,
         },
@@ -36,8 +34,7 @@ const routes = [
         },
       },
       {
-        path: "posts/:id",
-        name: "PostModal",
+        ...pages.post(":id"),
         components: {
           page: PostModal,
         },
@@ -48,8 +45,7 @@ const routes = [
     ],
   },
   {
-    path: "/login",
-    name: "LoginPage",
+    ...pages.login,
     component: LoginPage,
   },
 ];


### PR DESCRIPTION
resolve #243 

`doran-pages` 플러그인을 추가해서 `this.$pages`로 접근할 수 있도록 했습니다.

플러그인을 사용한 이유는 `router-link`에서 사용하기 위함입니다.
기존 constants에 있는 것들처럼 선언하게 되면 각 컴포넌트에서 data로 받은 다음에 to 속성에 넣어야하는 이상한 형태가 되어버려서...
또 상수로 선언하기엔 path가 쿼리문을 사용하게 된다면 유동적인 경우도 있어서 이게 정말 상수가 맞는가? 싶은 부분도 있습니다.

근데 이게 또 괜찮은건진 잘 모르겠네요.
다른 분들의 의견이 궁금합니다.

그냥 사용되는 모든 컴포넌트에서 import하고 data로 받아서 하는 게 맞을까요?
지금 당장은 `router-link`를 이용하는 부분이 한 군데밖에 없기도 하고요 🤔