### PR TITLE
feature/249 게시글, 댓글 생성 시 memberId를 요구하지 않도록 변경한다

### DIFF
--- a/front/src/components/map/PostCreateModal.vue
+++ b/front/src/components/map/PostCreateModal.vue
@@ -85,7 +85,6 @@ export default {
         return;
       }
       const data = {
-        memberId: 1,
         content: this.content,
         location: postLocation,
         address: await this.$kakaoMap.getAddress(postLocation),

--- a/front/src/components/post/CommentInput.vue
+++ b/front/src/components/post/CommentInput.vue
@@ -55,7 +55,6 @@ export default {
         return;
       }
       const data = {
-        memberId: 1,
         postId: this.postId,
         content: this.content,
         location: authorLocation,

--- a/src/main/java/com/grasshouse/dorandoran/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/grasshouse/dorandoran/comment/dto/CommentCreateRequest.java
@@ -16,9 +16,6 @@ import org.hibernate.validator.constraints.Length;
 public class CommentCreateRequest {
 
     @NotNull
-    private Long memberId;
-
-    @NotNull
     private Long postId;
 
     @Length(max = 120)

--- a/src/main/java/com/grasshouse/dorandoran/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/dto/PostCreateRequest.java
@@ -18,9 +18,6 @@ import org.hibernate.validator.constraints.Length;
 @AllArgsConstructor
 public class PostCreateRequest {
 
-    @NotNull
-    private Long memberId;
-
     private Address authorAddress;
 
     @Length(max = 200)


### PR DESCRIPTION
Resolves #249 

 - 프론트에서 POST("/posts"), POST("/comments") 요청 시 memberId 제거
 - PostCreateRequest, CommentCreateRequest에서 memberId 제거

매우 간단한 PR이네요.
코드 훑어보다가 이상한 코드가 있어서 제거했습니다.
빠르게 머지합시다.