### PR TITLE
feature/227 위치정보를 불러올 수 없는 경우 위치정보가 필요한 기능들을 막는다.

### DIFF
--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -65,9 +65,9 @@ export default {
     },
     async checkOsEnvironment() {
       let isMobile = false;
-      const filter = "win16|win32|win64|mac|macIntel";
+      const filter = "win16|win32|win64|mac|macintel";
       if (navigator.platform) {
-        isMobile = filter.indexOf(navigator.platform.toLowerCase()) < 0;
+        isMobile = !filter.includes(navigator.platform.toLowerCase());
       }
       if (isMobile) {
         await this.$store.commit("member/SET_ENVIRONMENT_MOBILE");

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -36,7 +36,7 @@ export default {
   },
   async mounted() {
     const map = await this.$kakaoMap.drawMap(this.$refs.map);
-    await this.giveCustomizedMessage();
+    await this.showCustomizedMessage();
     this.$store.commit("map/SET_MAP", map);
     await this.$kakaoMap.setCenterByCurrentLocation().catch(() => {});
     await this.changeAppBarByCenterAddress();
@@ -63,7 +63,7 @@ export default {
         })
         .catch(() => {});
     },
-    async checkMemberEnvironment() {
+    async checkOsEnvironment() {
       let isMobile = false;
       const filter = "win16|win32|win64|mac|macIntel";
       if (navigator.platform) {
@@ -73,9 +73,9 @@ export default {
         await this.$store.commit("member/SET_ENVIRONMENT_MOBILE");
       } else await this.$store.commit("member/SET_ENVIRONMENT_PC");
     },
-    async giveCustomizedMessage() {
+    async showCustomizedMessage() {
       await this.checkMemberLocationInformation();
-      await this.checkMemberEnvironment();
+      await this.checkOsEnvironment();
       const hasLocationInformation = this.$store.getters[
         "member/hasLocationInformation"
       ];

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -63,34 +63,30 @@ export default {
         })
         .catch(() => {});
     },
-    async checkOsEnvironment() {
+    _checkIfMobile() {
       let isMobile = false;
       const filter = "win16|win32|win64|mac|macintel";
       if (navigator.platform) {
         isMobile = !filter.includes(navigator.platform.toLowerCase());
       }
-      if (isMobile) {
-        await this.$store.commit("member/SET_ENVIRONMENT", "MOBILE");
-      } else await this.$store.commit("member/SET_ENVIRONMENT", "PC");
+      return isMobile;
     },
     async showCustomizedMessage() {
       await this.checkMemberLocationInformation();
-      await this.checkOsEnvironment();
       const hasLocationInformation = this.$store.getters[
         "member/hasLocationInformation"
       ];
-      const environment = this.$store.getters["member/getEnvironment"];
+      let isMobile = this._checkIfMobile();
       if (!hasLocationInformation) {
-        if (environment === "PC") {
-          this.$store.commit(
-            "snackbar/SHOW",
-            ERROR_MESSAGE.UNIDENTIFIABLE_LOCATION_PC,
-          );
-        }
-        if (environment === "MOBILE") {
+        if (isMobile) {
           this.$store.commit(
             "snackbar/SHOW",
             ERROR_MESSAGE.UNIDENTIFIABLE_LOCATION_MOBILE,
+          );
+        } else {
+          this.$store.commit(
+            "snackbar/SHOW",
+            ERROR_MESSAGE.UNIDENTIFIABLE_LOCATION_PC,
           );
         }
       }

--- a/front/src/components/map/KakaoMap.vue
+++ b/front/src/components/map/KakaoMap.vue
@@ -59,7 +59,7 @@ export default {
       await this.$kakaoMap
         .getCurrentLocation()
         .then(() => {
-          this.$store.commit("member/SET_LOCATION_INFORMATION_TRUE");
+          this.$store.commit("member/SET_LOCATION_INFORMATION", true);
         })
         .catch(() => {});
     },
@@ -70,8 +70,8 @@ export default {
         isMobile = !filter.includes(navigator.platform.toLowerCase());
       }
       if (isMobile) {
-        await this.$store.commit("member/SET_ENVIRONMENT_MOBILE");
-      } else await this.$store.commit("member/SET_ENVIRONMENT_PC");
+        await this.$store.commit("member/SET_ENVIRONMENT", "MOBILE");
+      } else await this.$store.commit("member/SET_ENVIRONMENT", "PC");
     },
     async showCustomizedMessage() {
       await this.checkMemberLocationInformation();

--- a/front/src/components/map/MapAssistantButtons.vue
+++ b/front/src/components/map/MapAssistantButtons.vue
@@ -18,6 +18,9 @@ export default {
     async setCenterByCurrentLocation() {
       await this.$kakaoMap
         .setCenterByCurrentLocation()
+        .then(() => {
+          this.$store.commit("member/SET_LOCATION_INFORMATION", true);
+        })
         .catch(() =>
           this.$store.commit(
             "snackbar/SHOW",

--- a/front/src/components/map/MapPage.vue
+++ b/front/src/components/map/MapPage.vue
@@ -15,7 +15,10 @@
         목록
       </router-link>
       <MapAssistantButtons v-show="isDefaultMode" />
-      <PostCreateButton class="post-create-btn" />
+      <PostCreateButton
+        v-show="isLocationIdentifiable"
+        class="post-create-btn"
+      />
       <PostCreateModal v-if="isPostMode" />
       <TimelineModal v-if="timeline" />
     </template>
@@ -62,6 +65,9 @@ export default {
     },
     isPostMode() {
       return this.$store.getters["map/isPost"];
+    },
+    isLocationIdentifiable() {
+      return this.$store.getters["member/hasLocationInformation"];
     },
   },
   created() {

--- a/front/src/components/post/PostModal.vue
+++ b/front/src/components/post/PostModal.vue
@@ -38,7 +38,7 @@
       </div>
       <CommentList :comments="post.comments" @load-post="loadPost" />
       <VSpacer class="bottom-spacer" />
-      <CommentInput :post-id="post.id" />
+      <CommentInput v-if="isLocationIdentifiable" :post-id="post.id" />
       <PostLocationModal
         v-if="isMapModalVisible"
         :location="post.location"
@@ -110,6 +110,9 @@ export default {
     },
     authorAddress() {
       return Object.values(this.post.authorAddress).join(" ");
+    },
+    isLocationIdentifiable() {
+      return this.$store.getters["member/hasLocationInformation"];
     },
   },
   async created() {

--- a/front/src/store/modules/member.js
+++ b/front/src/store/modules/member.js
@@ -25,17 +25,11 @@ export default {
       state.member.createdAt = "";
       state.member.updatedAt = "";
     },
-    SET_LOCATION_INFORMATION_TRUE(state) {
-      state.locationInformation = true;
+    SET_LOCATION_INFORMATION(state, payload) {
+      state.locationInformation = payload;
     },
-    SET_LOCATION_INFORMATION_FALSE(state) {
-      state.locationInformation = false;
-    },
-    SET_ENVIRONMENT_PC(state) {
-      state.environment = "PC";
-    },
-    SET_ENVIRONMENT_MOBILE(state) {
-      state.environment = "MOBILE";
+    SET_ENVIRONMENT(state, environment) {
+      state.environment = environment;
     },
   },
   actions: {

--- a/front/src/store/modules/member.js
+++ b/front/src/store/modules/member.js
@@ -11,7 +11,6 @@ export default {
       updatedAt: "",
     },
     locationInformation: false,
-    environment: "",
   },
   mutations: {
     SET_MEMBER(state, member) {
@@ -27,9 +26,6 @@ export default {
     },
     SET_LOCATION_INFORMATION(state, payload) {
       state.locationInformation = payload;
-    },
-    SET_ENVIRONMENT(state, environment) {
-      state.environment = environment;
     },
   },
   actions: {
@@ -57,9 +53,6 @@ export default {
     },
     hasLocationInformation: (state) => {
       return state.locationInformation;
-    },
-    getEnvironment: (state) => {
-      return state.environment;
     },
   },
 };

--- a/front/src/store/modules/member.js
+++ b/front/src/store/modules/member.js
@@ -10,6 +10,8 @@ export default {
       createdAt: "",
       updatedAt: "",
     },
+    locationInformation: false,
+    environment: "",
   },
   mutations: {
     SET_MEMBER(state, member) {
@@ -22,6 +24,18 @@ export default {
       state.member.picture = "";
       state.member.createdAt = "";
       state.member.updatedAt = "";
+    },
+    SET_LOCATION_INFORMATION_TRUE(state) {
+      state.locationInformation = true;
+    },
+    SET_LOCATION_INFORMATION_FALSE(state) {
+      state.locationInformation = false;
+    },
+    SET_ENVIRONMENT_PC(state) {
+      state.environment = "PC";
+    },
+    SET_ENVIRONMENT_MOBILE(state) {
+      state.environment = "MOBILE";
     },
   },
   actions: {
@@ -46,6 +60,12 @@ export default {
         state.member.id !== 0 &&
         state.member.createdAt === state.member.updatedAt
       );
+    },
+    hasLocationInformation: (state) => {
+      return state.locationInformation;
+    },
+    getEnvironment: (state) => {
+      return state.environment;
     },
   },
 };

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -1,5 +1,7 @@
 const ERROR_MESSAGE = {
   UNIDENTIFIABLE_LOCATION: "😢 위치 정보를 확인할 수 없습니다.",
+  UNIDENTIFIABLE_LOCATION_PC: "😢 위치 정보를 불러올 수 없습니다. 모바일 환경 사용을 권장합니다.",
+  UNIDENTIFIABLE_LOCATION_MOBILE: "😢 위치 정보를 불러올 수 없습니다. 둘러보기만 가능합니다.",
   NO_CONTENT_MESSAGE: "🤔 내용을 입력해주세요.",
   NO_POST_MESSAGE: "😭 해당 기간에 글이 존재하지 않습니다.",
   NO_KEYWORD_INPUT: "🧐 키워드를 입력해주세요.",


### PR DESCRIPTION
Resolves #227 

사용자의 위치를 받아올 수 없는 경우
1. PC의 경우 -> 모바일 사용을 권장한다는 메세지를 띄워주고
2. 모바일의 경우 -> 둘러보기만 가능하다는 메세지를 띄워줬습니다.

그리고 위치정보가 필요한 기능들에서 `글쓰기 버튼`을 안 보이게 해줬어요.

원래 로그인이 안 된 경우도 맡아서 하려고 했는데 범위가 축소됐네요.
로그인이 안 된 경우 redirect 까지 해서 새로운 이슈를 파야 될 것 같아요.