### PR TITLE
feature/248 캐싱이 적용된 nginx 설정 파일을 버전 관리한다.

### DIFF
--- a/nginx/cache.conf
+++ b/nginx/cache.conf
@@ -1,0 +1,31 @@
+# cat /etc/nginx/sites-available/default
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+	root /home/ubuntu/dev/front/dist;
+
+    # Add index.php to the list if you are using PHP
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name _;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+    location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+        expires -1;
+    }
+
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    location ~* \.(?:css|js)$ {
+        expires 1y;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+}

--- a/nginx/cache.conf
+++ b/nginx/cache.conf
@@ -1,11 +1,9 @@
-# cat /etc/nginx/sites-available/default
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
 	root /home/ubuntu/dev/front/dist;
 
-    # Add index.php to the list if you are using PHP
     index index.html index.htm index.nginx-debian.html;
 
     server_name _;

--- a/nginx/cache.conf
+++ b/nginx/cache.conf
@@ -15,13 +15,7 @@ server {
         expires -1;
     }
 
-    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-        expires 1M;
-        access_log off;
-        add_header Cache-Control "public";
-    }
-
-    location ~* \.(?:css|js)$ {
+    location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
         expires 1y;
         access_log off;
         add_header Cache-Control "public";


### PR DESCRIPTION
resolve #246, resolve #248 

jpg 등의 이미지 파일은 캐싱 기간 1달,
css, js 파일은 1년으로 설정했습니다.
<img width="497" alt="스크린샷 2020-10-20 오후 5 22 16" src="https://user-images.githubusercontent.com/45786387/96560108-ce769780-12f8-11eb-880f-d5105aeb7d3f.png">
Expires가 2021년이군요.

---

<img width="729" alt="스크린샷 2020-10-20 오후 5 15 01" src="https://user-images.githubusercontent.com/45786387/96559285-cc600900-12f7-11eb-84b7-b7ecd4ba2675.png">
jenkins-dev에 이걸 추가했습니다.
prod에는 dev 작동 여부 보고 변경하겠습니다.

---

<img width="308" alt="스크린샷 2020-10-20 오후 5 21 01" src="https://user-images.githubusercontent.com/45786387/96559957-a1c28000-12f8-11eb-8052-c30eb3c7000f.png">
nginx.conf에서 nginx 폴더에 있는 모든 conf 파일을 읽어오도록 변경했어요.