### PR TITLE
feature/259 날짜 필터링 로직 변경

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -111,7 +111,7 @@ export default {
   box-shadow: 0 0 40px 2px gray;
 }
 
-.app-container > div {
+.app-container > .v-application--wrap {
   min-height: 100%;
   height: 100%;
 }

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -59,24 +59,28 @@ export default {
       this.dates = [];
     },
     selected() {
-      if (this.dates.length < 2) {
+      if (this.dates.length < 1) {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_DATE_COUNT);
-        return false;
+        return;
       }
 
-      const startDate = this.$moment(this.dates[0]);
-      const endDate = this.$moment(this.dates[1]);
-
-      if (startDate.isAfter(endDate)) {
-        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_DATE_ORDER);
-        this.dates = [];
-        return false;
+      if (this.dates.length === 1) {
+        const oneDate = this.dates[0];
+        this.dates = [oneDate, oneDate];
+        return;
       }
 
-      if (startDate.isBefore(endDate.subtract(1, "months"))) {
-        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_30_DAYS);
+      const startDate = new Date(this.dates[0]);
+      const endDate = new Date(this.dates[1]);
+
+      if (startDate < endDate.getMonth() - 1) {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_A_MONTH);
         this.dates = [];
-        return false;
+        return;
+      }
+
+      if (startDate > endDate) {
+        this.dates = [this.endDate, this.startDate];
       }
 
       this.$emit("select", this.dates);

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -1,11 +1,17 @@
 <template>
-  <v-menu v-model="menu" offset-y transition="scale-transition">
+  <v-menu
+    v-model="menu"
+    :close-on-content-click="false"
+    :return-value.sync="dates"
+    offset-y
+    transition="scale-transition"
+  >
     <template v-slot:activator="{ on, attrs }">
       <VTextField
         v-on="on"
         v-bind="attrs"
-        v-model="date"
-        :placeholder="label"
+        v-model="joinDates"
+        :placeholder="'날짜 구간을 선택하세요.'"
         prepend-icon="mdi-calendar"
         readonly
         single-line
@@ -15,29 +21,58 @@
         class="font-size-x-small"
       />
     </template>
-    <VDatePicker v-model="date" no-title scrollable @input="selectDate" />
+    <VDatePicker
+      v-model="dates"
+      range
+      no-title
+      scrollable
+      @input="selectDate"
+    />
   </v-menu>
 </template>
 
 <script>
+import { ERROR_MESSAGE } from "@/utils/constants";
+
 export default {
   name: "DatePickerMenu",
-  props: {
-    label: {
-      type: String,
-      required: true,
-    },
-  },
   data() {
     return {
+      dates: [],
       menu: false,
-      date: "",
     };
+  },
+  computed: {
+    joinDates() {
+      if (this.dates.length === 0) {
+        return "";
+      }
+      return this.dates.join(" ~ ");
+    },
   },
   methods: {
     selectDate() {
+      if (this.dates.length < 2) {
+        return;
+      }
+
+      const startDate = this.$moment(this.dates[0]);
+      const endDate = this.$moment(this.dates[1]);
+
+      if (startDate.isAfter(endDate)) {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_DATE_ORDER);
+        this.dates = [];
+        return;
+      }
+
+      if (startDate.isBefore(endDate.subtract(1, "months"))) {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_30_DAYS);
+        this.dates = [];
+        return;
+      }
+
       this.menu = false;
-      this.$emit("select", this.date);
+      this.$emit("select", this.dates);
     },
   },
 };

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -69,21 +69,26 @@ export default {
         this.dates = [singleDate, singleDate];
       }
 
-      const startDate = new Date(this.dates[0]);
-      const endDate = new Date(this.dates[1]);
+      let [startDate, endDate] = this.dates;
 
-      if (startDate < endDate.getMonth() - 1) {
+      if (startDate > endDate) {
+        this.dates = this.dates.reverse();
+        [startDate, endDate] = this.dates;
+      }
+
+      if (this.isOverAMonth(startDate, endDate)) {
         this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_A_MONTH);
         this.dates = [];
         return;
       }
 
-      if (startDate > endDate) {
-        this.dates = this.dates.reverse();
-      }
-
-      this.$emit("select", this.dates);
+      this.$emit("select", startDate, endDate);
       this.menu = false;
+    },
+    isOverAMonth(startDate, endDate) {
+      startDate = this.$moment(startDate);
+      endDate = this.$moment(endDate);
+      return startDate.isBefore(endDate.subtract(1, "months"));
     },
     close() {
       this.dates = [];

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -65,9 +65,8 @@ export default {
       }
 
       if (this.dates.length === 1) {
-        const oneDate = this.dates[0];
-        this.dates = [oneDate, oneDate];
-        return;
+        const singleDate = this.dates[0];
+        this.dates = [singleDate, singleDate];
       }
 
       const startDate = new Date(this.dates[0]);
@@ -80,7 +79,7 @@ export default {
       }
 
       if (startDate > endDate) {
-        this.dates = [this.endDate, this.startDate];
+        this.dates = this.dates.reverse();
       }
 
       this.$emit("select", this.dates);

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -100,5 +100,6 @@ export default {
   background-color: white;
   margin-top: 5px;
   margin-left: -10px;
+  overflow: hidden;
 }
 </style>

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -1,5 +1,6 @@
 <template>
   <v-menu
+    refs="menu"
     v-model="menu"
     :close-on-content-click="false"
     :return-value.sync="dates"
@@ -11,7 +12,7 @@
         v-on="on"
         v-bind="attrs"
         v-model="joinDates"
-        :placeholder="'날짜 구간을 선택하세요.'"
+        :placeholder="'날짜를 입력해주세요.'"
         prepend-icon="mdi-calendar"
         readonly
         single-line
@@ -21,13 +22,13 @@
         class="font-size-x-small"
       />
     </template>
-    <VDatePicker
-      v-model="dates"
-      range
-      no-title
-      scrollable
-      @input="selectDate"
-    />
+    <div class="flex-column">
+      <VDatePicker v-model="dates" range no-title @input="selectDate" />
+      <div class="d-flex flex-row-reverse mb-3 mr-1">
+        <v-btn text @click="$refs.menu.save(dates)">선택</v-btn>
+        <v-btn text @click="menu = false">닫기</v-btn>
+      </div>
+    </div>
   </v-menu>
 </template>
 
@@ -71,7 +72,6 @@ export default {
         return;
       }
 
-      this.menu = false;
       this.$emit("select", this.dates);
     },
   },
@@ -80,7 +80,8 @@ export default {
 
 <style scoped>
 .v-menu__content {
-  min-height: 290px;
-  height: 290px;
+  min-height: 330px;
+  height: 330px;
+  background-color: white;
 }
 </style>

--- a/front/src/components/map/filter/DatePickerMenu.vue
+++ b/front/src/components/map/filter/DatePickerMenu.vue
@@ -92,8 +92,9 @@ export default {
 
 <style scoped>
 .v-menu__content {
-  min-height: 330px;
   height: 330px;
   background-color: white;
+  margin-top: 5px;
+  margin-left: -10px;
 }
 </style>

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -36,9 +36,7 @@
     </transition>
 
     <v-sheet v-show="isCalendarOpen" class="px-3 py-0 filter-calendar">
-      <DatePickerMenu :label="'시작 날짜'" @select="inputStartDate" />
-      <span class="mx-3 pt-2">~</span>
-      <DatePickerMenu :label="'종료 날짜'" @select="inputEndDate" />
+      <DatePickerMenu @select="inputDates" />
     </v-sheet>
   </div>
 </template>
@@ -81,31 +79,11 @@ export default {
       this.$store.commit("post/filter/RESET_END_DATE");
       this.filterPosts();
     },
-    inputStartDate(date) {
-      this.startDate = period.format(date + " 00:00:00");
+    inputDates(dates) {
+      this.startDate = period.format(dates[0] + " 00:00:00");
       this.$store.commit("post/filter/SET_START_DATE", this.startDate);
-      if (this.endDate) {
-        this.handleUserInputFiltering();
-      }
-    },
-    inputEndDate(date) {
-      this.endDate = period.format(date + " 23:59:59");
+      this.endDate = period.format(dates[1] + " 00:00:00");
       this.$store.commit("post/filter/SET_END_DATE", this.endDate);
-      if (this.startDate) {
-        this.handleUserInputFiltering();
-      }
-    },
-    handleUserInputFiltering() {
-      if (this.startDate > this.endDate) {
-        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_DATE_ORDER);
-        return;
-      }
-
-      const beforeOneMonth = this.$moment(this.endDate).subtract(1, "months");
-      if (this.$moment(beforeOneMonth).isAfter(this.startDate)) {
-        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_30_DAYS);
-        return;
-      }
 
       this.filterPosts();
     },

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -79,10 +79,10 @@ export default {
       this.$store.commit("post/filter/RESET_END_DATE");
       this.filterPosts();
     },
-    inputDates(dates) {
-      this.startDate = period.format(dates[0] + " 00:00:00");
+    inputDates(startDate, endDate) {
+      this.startDate = period.format(startDate + " 00:00:00");
       this.$store.commit("post/filter/SET_START_DATE", this.startDate);
-      this.endDate = period.format(dates[1] + " 23:59:59");
+      this.endDate = period.format(endDate + " 23:59:59");
       this.$store.commit("post/filter/SET_END_DATE", this.endDate);
 
       this.filterPosts();

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -82,7 +82,7 @@ export default {
     inputDates(dates) {
       this.startDate = period.format(dates[0] + " 00:00:00");
       this.$store.commit("post/filter/SET_START_DATE", this.startDate);
-      this.endDate = period.format(dates[1] + " 00:00:00");
+      this.endDate = period.format(dates[1] + " 23:59:59");
       this.$store.commit("post/filter/SET_END_DATE", this.endDate);
 
       this.filterPosts();

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -97,12 +97,16 @@ export default {
     },
     handleUserInputFiltering() {
       if (this.startDate > this.endDate) {
-        this.$store.commit(
-          "snackbar/SHOW",
-          ERROR_MESSAGE.INVALID_USER_DATE_INPUT,
-        );
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_DATE_ORDER);
         return;
       }
+
+      const beforeOneMonth = this.$moment(this.endDate).subtract(1, "months");
+      if (this.$moment(beforeOneMonth).isAfter(this.startDate)) {
+        this.$store.commit("snackbar/SHOW", ERROR_MESSAGE.INVALID_OVER_30_DAYS);
+        return;
+      }
+
       this.filterPosts();
     },
     async filterPosts() {

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -147,11 +147,10 @@ export default {
   left: 45px;
   z-index: 1;
   max-width: 60%;
-  padding-top: 5px;
-  padding-left: 10px;
   border-radius: 24px;
   box-shadow: 1px 1px 8px silver;
   background-color: white;
+  min-width: 190px;
 }
 
 .slide-right-enter-active {

--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -99,9 +99,11 @@ export default {
   watch: {
     async selected(val) {
       if (val === this.periodOptions.CUSTOM) {
-        this.$store.commit("post/filter/SET_START_DATE", this.startDate);
-        this.$store.commit("post/filter/SET_END_DATE", this.endDate);
-        await this.filterPosts();
+        if (this.startDate) {
+          this.$store.commit("post/filter/SET_START_DATE", this.startDate);
+          this.$store.commit("post/filter/SET_END_DATE", this.endDate);
+          await this.filterPosts();
+        }
         this.openCalendar();
         return;
       }

--- a/front/src/store/modules/filter.js
+++ b/front/src/store/modules/filter.js
@@ -13,9 +13,15 @@ export default {
       state.keyword = keyword;
     },
     SET_START_DATE(state, startDate) {
+      if (startDate === "") {
+        return;
+      }
       state.startDate = startDate;
     },
     SET_END_DATE(state, endDate) {
+      if (endDate === "") {
+        return;
+      }
       state.endDate = endDate;
     },
     RESET_END_DATE(state) {

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -6,8 +6,7 @@ const ERROR_MESSAGE = {
   NO_SEARCH_RESULT_MESSAGE: "😭 해당 키워드의 검색 결과가 없습니다.",
   EXECUTION_ERROR: "😭 에러가 발생했습니다.",
   INVALID_DATE_COUNT: "😨 시작 날짜와 종료 날짜를 입력해주세요.",
-  INVALID_DATE_ORDER: "😨 시작 날짜는 종료 날짜보다 뒤일 수 없습니다.",
-  INVALID_OVER_30_DAYS: "😨 최대 30일간 조회가 가능합니다.",
+  INVALID_OVER_A_MONTH: "😨 최대 한 달 간 조회가 가능합니다.",
   LOGIN_REQUIRED: "🔑 로그인이 필요해요.",
 };
 

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -5,7 +5,8 @@ const ERROR_MESSAGE = {
   NO_KEYWORD_INPUT: "🧐 키워드를 입력해주세요.",
   NO_SEARCH_RESULT_MESSAGE: "😭 해당 키워드의 검색 결과가 없습니다.",
   EXECUTION_ERROR: "😭 에러가 발생했습니다.",
-  INVALID_USER_DATE_INPUT: "😨 시작 날짜는 종료 날짜보다 뒤일 수 없습니다.",
+  INVALID_DATE_ORDER: "😨 시작 날짜는 종료 날짜보다 뒤일 수 없습니다.",
+  INVALID_OVER_30_DAYS: "😨 최대 30일간 조회가 가능합니다.",
   LOGIN_REQUIRED: "🔑 로그인이 필요해요.",
 };
 

--- a/front/src/utils/constants.js
+++ b/front/src/utils/constants.js
@@ -5,6 +5,7 @@ const ERROR_MESSAGE = {
   NO_KEYWORD_INPUT: "🧐 키워드를 입력해주세요.",
   NO_SEARCH_RESULT_MESSAGE: "😭 해당 키워드의 검색 결과가 없습니다.",
   EXECUTION_ERROR: "😭 에러가 발생했습니다.",
+  INVALID_DATE_COUNT: "😨 시작 날짜와 종료 날짜를 입력해주세요.",
   INVALID_DATE_ORDER: "😨 시작 날짜는 종료 날짜보다 뒤일 수 없습니다.",
   INVALID_OVER_30_DAYS: "😨 최대 30일간 조회가 가능합니다.",
   LOGIN_REQUIRED: "🔑 로그인이 필요해요.",

--- a/front/src/utils/period.js
+++ b/front/src/utils/period.js
@@ -39,7 +39,7 @@ const PERIOD_OPTIONS = {
     startDate: () => period.ago(30, PERIOD_TYPE.DAY),
   },
   CUSTOM: {
-    order: 5,
+    order: 4,
     title: "직접입력",
   },
 };

--- a/front/src/utils/period.js
+++ b/front/src/utils/period.js
@@ -38,11 +38,6 @@ const PERIOD_OPTIONS = {
     title: "30일 이내",
     startDate: () => period.ago(30, PERIOD_TYPE.DAY),
   },
-  ALL: {
-    order: 4,
-    title: "전체",
-    startDate: () => "",
-  },
   CUSTOM: {
     order: 5,
     title: "직접입력",

--- a/src/main/java/com/grasshouse/dorandoran/post/service/PostService.java
+++ b/src/main/java/com/grasshouse/dorandoran/post/service/PostService.java
@@ -38,12 +38,6 @@ public class PostService {
     }
 
     @Transactional
-    public List<PostResponse> showPosts() {
-        List<Post> posts = postRepository.findAll();
-        return PostResponse.listFrom(posts);
-    }
-
-    @Transactional
     public void deletePost(Long id, Member member) {
         Post post = postRepository.findById(id)
             .orElseThrow(PostNotFoundException::new);

--- a/src/test/java/com/grasshouse/dorandoran/post/service/PostServiceTest.java
+++ b/src/test/java/com/grasshouse/dorandoran/post/service/PostServiceTest.java
@@ -78,19 +78,6 @@ class PostServiceTest {
         assertThat(postResponse.getContent()).isEqualTo(persistPost.getContent());
     }
 
-    @DisplayName("전체 글을 조회한다.")
-    @Test
-    void showPostsTest() {
-        Post post = dummyPost();
-
-        Post persistPost = postRepository.save(post);
-
-        List<PostResponse> postResponses = postService.showPosts();
-
-        assertThat(postResponses).hasSize(1);
-        assertThat(postResponses.get(0).getContent()).isEqualTo(persistPost.getContent());
-    }
-
     @DisplayName("글을 삭제한다.")
     @Test
     void deletePostTest() {


### PR DESCRIPTION
Resolves #259

1. `전체` 버튼 없애기
2. `직접 입력` 30일로 제한
3. `직졉 입력` 선택 시 기존 캘린더 2개로 선택하던 방식에서 1개로 시작, 종료 날짜 처리할 수 있도록 변경