### PR TITLE
hotfix/263 직접 입력을 최초로 선택할 때 전체 검색이 되지 않도록 수정한다.

### DIFF
--- a/front/src/components/map/filter/PeriodFilterButton.vue
+++ b/front/src/components/map/filter/PeriodFilterButton.vue
@@ -117,9 +117,11 @@ export default {
   watch: {
     async selected(val) {
       if (val === this.periodOptions.CUSTOM) {
-        this.$store.commit("post/filter/SET_START_DATE", this.startDate);
-        this.$store.commit("post/filter/SET_END_DATE", this.endDate);
-        await this.filterPosts();
+        if (this.startDate) {
+          this.$store.commit("post/filter/SET_START_DATE", this.startDate);
+          this.$store.commit("post/filter/SET_END_DATE", this.endDate);
+          await this.filterPosts();
+        }
         this.openCalendar();
         return;
       }


### PR DESCRIPTION
Resolves #263 

리뷰하던 도중 발견해서 수정합니다.
`periodOptions.CUSTOM`일 때 `startDate`의 존재 여부로 한번 더 검증해서 `startDate`에 `""`가 넣어지는 일이 없도록 했습니다.

아침에 데일리 미팅 하면서 한번 확인하고 머지하면 좋겠네요.

추가적으로 #259에서 전체 검색이 아예 사라진다면 `store.filter.SET_START_DATE()`에서 `startDate`가 빈 경우가 없도록 검증 절차를 한번 거치는 게 좋을 것 같네요.
실수로 빈거 넣어서 전체 검색 실행할 수 없도록 말예요.